### PR TITLE
Aligned save expectation traces on crowdstrike behavior

### DIFF
--- a/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
+++ b/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
@@ -330,6 +330,7 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
             "Found " + str(len(alerts.results)) + " alerts with signatures"
         )
         # For each expectation, try to find the proper alert to assign a detection or prevention result
+        traces_to_create: list[dict[str, str]] = []
         for expectation in expectations:
             # Check expired expectation
             expectation_date = parse(
@@ -403,8 +404,8 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
                         + ")"
                     )
                     for evidence in evidences:
-                        self.api.inject_expectation_trace.create(
-                            data={
+                        traces_to_create.append(
+                            {
                                 "inject_expectation_trace_expectation": expectation[
                                     "inject_expectation_id"
                                 ],
@@ -422,6 +423,10 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
                                 ),
                             }
                         )
+
+        self.api.inject_expectation_trace.bulk_create(
+            payload={"expectation_traces": traces_to_create}
+        )
 
     def _process_message(self) -> None:
         # Auth

--- a/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
+++ b/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
@@ -423,7 +423,6 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
                                 ),
                             }
                         )
-
         self.api.inject_expectation_trace.bulk_create(
             payload={"expectation_traces": traces_to_create}
         )

--- a/microsoft-sentinel/microsoft_sentinel/openaev_microsoft_sentinel.py
+++ b/microsoft-sentinel/microsoft_sentinel/openaev_microsoft_sentinel.py
@@ -157,6 +157,7 @@ class OpenAEVMicrosoftSentinel(CollectorDaemon):
 
         endpoint_per_asset = {}
         # For each expectation, try to find the proper alert to assign a detection or prevention result
+        traces_to_create: list[dict[str, str]] = []
         for expectation in expectations:
             if expectation["inject_expectation_asset"] not in endpoint_per_asset:
                 endpoint_per_asset[expectation["inject_expectation_asset"]] = (
@@ -242,8 +243,8 @@ class OpenAEVMicrosoftSentinel(CollectorDaemon):
                             + expectation["inject_expectation_type"]
                             + ")"
                         )
-                        self.api.inject_expectation_trace.create(
-                            data={
+                        traces_to_create.append(
+                            {
                                 "inject_expectation_trace_expectation": expectation[
                                     "inject_expectation_id"
                                 ],
@@ -267,6 +268,9 @@ class OpenAEVMicrosoftSentinel(CollectorDaemon):
                                 ],
                             }
                         )
+        self.api.inject_expectation_trace.bulk_create(
+            payload={"expectation_traces": traces_to_create}
+        )
 
     def _process_message(self) -> None:
         self._process_alerts()

--- a/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
+++ b/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
@@ -324,9 +324,10 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
                             }
                         )
 
-        self.helper.api.inject_expectation_trace.bulk_create(
+        self.api.inject_expectation_trace.bulk_create(
             payload={"expectation_traces": traces_to_create}
         )
+
 
 if __name__ == "__main__":
     for key in [

--- a/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
+++ b/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
@@ -245,6 +245,7 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
         self.logger.info("Found " + str(len(alerts)) + " alerts (taking first 200)")
 
         # For each expectation, try to find the proper alert to assign a detection or prevention result
+        traces_to_create: list[dict[str, str]] = []
         for expectation in expectations:
             if expectation in expectations_not_filled:
                 # Check expired expectation
@@ -303,8 +304,8 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
                             + expectation["inject_expectation_type"]
                             + ")"
                         )
-                        self.api.inject_expectation_trace.create(
-                            data={
+                        traces_to_create.append(
+                            {
                                 "inject_expectation_trace_expectation": expectation[
                                     "inject_expectation_id"
                                 ],
@@ -323,6 +324,9 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
                             }
                         )
 
+        self.helper.api.inject_expectation_trace.bulk_create(
+            payload={"expectation_traces": traces_to_create}
+        )
 
 if __name__ == "__main__":
     for key in [


### PR DESCRIPTION

### Proposed changes

* Aligned save expectation traces on crowdstrike behavior, using bulk update instead of singular

### Related issues

* Closes issue #145 
* Closes issue #146 
* Closes issue #147 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
