### PR TITLE
[crowdstrike] fix(api): don't crash when no alerts are found in the crowdstrike backend

### DIFF
--- a/crowdstrike/crowdstrike/crowdstrike_api_handler.py
+++ b/crowdstrike/crowdstrike/crowdstrike_api_handler.py
@@ -29,6 +29,11 @@ class CrowdstrikeApiHandler:
         response = self.alerts.query_alerts_v2(parameters=parameters)
 
         if response["status_code"] == 200:
+            if not response["body"]["resources"]:
+                self.helper.collector_logger.warning(
+                    "No alerts found."
+                )
+                return
             alerts_response = self.alerts.get_alerts_v2(
                 composite_ids=response["body"]["resources"]
             )

--- a/crowdstrike/crowdstrike/crowdstrike_api_handler.py
+++ b/crowdstrike/crowdstrike/crowdstrike_api_handler.py
@@ -30,9 +30,7 @@ class CrowdstrikeApiHandler:
 
         if response["status_code"] == 200:
             if not response["body"]["resources"]:
-                self.helper.collector_logger.warning(
-                    "No alerts found."
-                )
+                self.helper.collector_logger.warning("No alerts found.")
                 return []
             alerts_response = self.alerts.get_alerts_v2(
                 composite_ids=response["body"]["resources"]

--- a/crowdstrike/crowdstrike/crowdstrike_api_handler.py
+++ b/crowdstrike/crowdstrike/crowdstrike_api_handler.py
@@ -33,7 +33,7 @@ class CrowdstrikeApiHandler:
                 self.helper.collector_logger.warning(
                     "No alerts found."
                 )
-                return
+                return []
             alerts_response = self.alerts.get_alerts_v2(
                 composite_ids=response["body"]["resources"]
             )


### PR DESCRIPTION
Original OP from #104 by @ItsmeCurly:

Credit for this PR: @ItsmeCurly 

> When no alerts are found, the resources is empty, so we exit before querying the alerts and clarify the error message.
> 
> <!--
> Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!
> 
> Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
> -->
> 
> ### Proposed changes
> 
> * Clarify logging, exit function before requesting alerts if no alerts found
> *
> 
> ### Related issues
> 
> * N/A
> *
> 
> ### Checklist
> 
> <!--
> Please submit the source code in a way, where you could honestly say `This code is finished`.
> If you feel that there are possibilities for improving the code quality, please do so.
> By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
> -->
> 
> - [x] I consider the submitted work as finished
> - [x] I tested the code for its functionality using different use cases
> - [ ] I added/update the relevant documentation (either on github or on notion)
> - [x] Where necessary I refactored code to improve the overall quality
> - [ ] For bug fix -> I implemented a test that covers the bug
> 
> <!-- For completed items, change [ ] to [x]. -->
> 
> ### Further comments
> 
> <!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
> 