### PR TITLE
[collector] fix(client): remove hardcoded api prefix from fqdn (#293)

### DIFF
--- a/palo-alto-cortex-xdr/README.md
+++ b/palo-alto-cortex-xdr/README.md
@@ -44,7 +44,7 @@ The collector receives **expectations** from OpenAEV, which are:
 #### API Calls to Cortex XDR
 The collector makes the following API calls:
 
-**Endpoint:** `POST https://api-{FQDN}/public_api/v1/alerts/get_alerts`
+**Endpoint:** `POST https://{FQDN}/public_api/v1/alerts/get_alerts`
 
 **Request Body:**
 ```json

--- a/palo-alto-cortex-xdr/src/services/client_api.py
+++ b/palo-alto-cortex-xdr/src/services/client_api.py
@@ -34,7 +34,7 @@ class PaloAltoCortexXDRClientAPI:
         if filters:
             request_data["filters"] = filters
 
-        url = f"https://api-{self.fqdn}/public_api/v1/alerts/get_alerts_multi_events"
+        url = f"https://{self.fqdn}/public_api/v1/alerts/get_alerts_multi_events"
         headers = self._auth.get_headers()
 
         response = requests.post(
@@ -49,7 +49,7 @@ class PaloAltoCortexXDRClientAPI:
     ) -> list[dict[str, Any]]:
         request_data = {"alert_id_list": alert_ids}
 
-        url = f"https://api-{self.fqdn}/public_api/v1/alerts/get_original_alerts"
+        url = f"https://{self.fqdn}/public_api/v1/alerts/get_original_alerts"
         headers = self._auth.get_headers()
 
         response = requests.post(
@@ -64,7 +64,7 @@ class PaloAltoCortexXDRClientAPI:
     ) -> Incident:
         request_data = {"incident_id": str(incident_id)}
 
-        url = f"https://api-{self.fqdn}/public_api/v1/incidents/get_incident_extra_data"
+        url = f"https://{self.fqdn}/public_api/v1/incidents/get_incident_extra_data"
         headers = self._auth.get_headers()
 
         response = requests.post(


### PR DESCRIPTION
## Summary

- Remove the hardcoded `api-` prefix prepended to the FQDN in `client_api.py` API URLs
- The FQDN config value is now used as-is, since users provide the full API hostname (e.g. `api-example.xdr.us.paloaltonetworks.com`)
- This fixes the doubled `api-api-...` hostname that caused DNS resolution failures

## Root cause

`client_api.py` built URLs as `https://api-{self.fqdn}/...`, but users (and the README) already include the `api-` prefix in the FQDN value, resulting in `api-api-{tenant}.xdr.{region}.paloaltonetworks.com`.

## Changes

- `client_api.py`: Removed `api-` prefix from all 3 API endpoint URLs
- `README.md`: Updated endpoint documentation to match

Closes #293