### PR TITLE
[ci] ci(all): enable unit tests via github actions with codecov (#296)

### DIFF
--- a/.github/workflows/tests-collectors.yml
+++ b/.github/workflows/tests-collectors.yml
@@ -1,0 +1,78 @@
+name: Tests Collectors
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Clone pyoaev (satisfies Poetry path dependency)
+        working-directory: ..
+        run: |
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            git clone -b main https://github.com/OpenAEV-Platform/client-python
+          else
+            git clone -b release/current https://github.com/OpenAEV-Platform/client-python
+          fi
+
+      - name: Install Poetry
+        working-directory: crowdstrike
+        run: pip install poetry==2.1.3 && poetry config installer.re-resolve false
+
+      - name: Install crowdstrike dependencies
+        working-directory: crowdstrike
+        run: poetry install --extras prod
+
+      - name: Overwrite pyoaev with correct version from CI
+        working-directory: crowdstrike
+        run: |
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            poetry run pip install --force-reinstall git+https://github.com/OpenAEV-Platform/client-python.git@main
+          else
+            poetry run pip install --force-reinstall git+https://github.com/OpenAEV-Platform/client-python.git@release/current
+          fi
+
+      - name: Install Coverage
+        working-directory: crowdstrike
+        run: poetry run pip install coverage
+
+      - name: Tests for crowdstrike collector
+        working-directory: crowdstrike
+        run: poetry run python -m coverage run -m unittest
+      
+      - name: Generate coverage XML
+        working-directory: crowdstrike
+        run: poetry run python -m coverage xml -o coverage.xml
+      
+      - name: Install dependencies for palo-alto-cortex-xdr
+        working-directory: palo-alto-cortex-xdr
+        run: poetry run pip install pytest factory-boy pyoaev coverage
+
+      - name: Tests for palo-alto-cortex-xdr collector
+        working-directory: palo-alto-cortex-xdr
+        run: poetry run python -m coverage run -m pytest
+      
+      - name: Generate coverage XML
+        working-directory: palo-alto-cortex-xdr
+        run: poetry run python -m coverage xml -o coverage.xml
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: connectors
+          fail_ci_if_error: false
+          verbose: true


### PR DESCRIPTION
### Proposed changes

* Add `.github/workflows/tests-collectors.yml` — new GitHub Actions workflow to run unit tests on push to `main` and on all pull requests
* Run coverage for the `crowdstrike` collector (`python -m coverage run -m unittest`), generate XML report, and upload to Codecov
* Run coverage for the `palo-alto-cortex-xdr` collector (`pytest` + coverage), generate XML report, and upload to Codecov
* Use branch-aware logic to clone the correct `client-python` (pyoaev): `main` → `main`, all other branches → `release/current`
* Coverage upload uses `codecov/codecov-action@v6` with `fail_ci_if_error: false` (non-blocking)

### Testing Instructions

1. Open a pull request against `main` — the `Tests Collectors` workflow should appear in the checks
2. Verify both the `crowdstrike` and `palo-alto-cortex-xdr` test steps pass
3. Check Codecov for a new coverage report with the `connectors` flag

### Related issues

* Closes #296

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

The `client-python` clone step uses `github.head_ref || github.ref_name` to detect the branch, routing non-`main` branches to `release/current`. This mirrors the existing CircleCI behaviour.

The Codecov upload step uses `if: ${{ !cancelled() }}` so coverage is always uploaded even when a previous step fails.