### PR TITLE
[all] ci(issues): add gh action for auto-labelling needs triage (#322)

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,19 @@
+name: Auto-label new issues
+on:
+  issues:
+    types: [opened, reopened]
+jobs:
+  add-needs-triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs triage']
+            });


### PR DESCRIPTION
### Proposed changes

* New github actions (workflows) for automatically adding "needs triage" label to opened and reopened issues

### Testing Instructions

1. Merge and create a new issue?

### Related issues

* Closes #322 

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

Code originally provided by @ncarenton (_credit where credit's due_)
