### PR TITLE
feat(sentinelone): adding an opt-out key for strict end date enforcement (#386)

### DIFF
--- a/sentinelone/README.md
+++ b/sentinelone/README.md
@@ -85,6 +85,7 @@ Below are the parameters you'll need to set for the collector:
 | Time Window              | sentinelone.time_window                   | `SENTINELONE_TIME_WINDOW`                   | PT1H                        | No        | Default search time window when no date signatures are provided (ISO 8601 format)       |
 | Expectation Batch Size   | sentinelone.expectation_batch_size        | `SENTINELONE_EXPECTATION_BATCH_SIZE`        | 50                          | No        | Number of expectations to process in each batch for batch-based processing              |
 | Enable Deep Visibility   | sentinelone.enable_deep_visibility_search | `SENTINELONE_ENABLE_DEEP_VISIBILITY_SEARCH` | false                       | No        | Enable Deep Visibility search for advanced threat detection (requires Complete license) |
+| Disable Strict End Date  | sentinelone.disable_strict_end_date       | `SENTINELONE_DISABLE_STRICT_END_DATE`       | false                       | No        | Disable ignoring OpenAEV expectations provided without an end date (may strongly impact API use) |
 
 ### Example Configuration Files
 
@@ -107,6 +108,7 @@ sentinelone:
   time_window: "PT1H"
   expectation_batch_size: 50
   enable_deep_visibility_search: false
+  disable_strict_end_date: false
 ```
 
 #### Environment Variables

--- a/sentinelone/src/models/configs/config_loader.py
+++ b/sentinelone/src/models/configs/config_loader.py
@@ -152,6 +152,9 @@ class ConfigLoader(ConfigBaseSettings):
                 "sentinelone_enable_deep_visibility_search": {
                     "data": self.sentinelone.enable_deep_visibility_search
                 },
+                "sentinelone_disable_strict_end_date": {
+                    "data": self.sentinelone.disable_strict_end_date
+                },
             },
             config_base_model=self,
         )

--- a/sentinelone/src/models/configs/sentinelone_configs.py
+++ b/sentinelone/src/models/configs/sentinelone_configs.py
@@ -37,3 +37,8 @@ class _ConfigLoaderSentinelOne(ConfigBaseSettings):
         default=False,
         description="Enable deep visibility search for SentinelOne threat searches.",
     )
+    disable_strict_end_date: bool = Field(
+        alias="SENTINELONE_DISABLE_STRICT_END_DATE",
+        default=False,
+        description="Disable ignoring OpenAEV expectations without a proper end dates.",
+    )

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -64,6 +64,7 @@ class SentinelOneExpectationService:
         self.enable_deep_visibility_search = (
             config.sentinelone.enable_deep_visibility_search
         )
+        self.disable_strict_end_date = config.sentinelone.disable_strict_end_date
 
         self.threat_fetcher: FetcherThreat = FetcherThreat(self.client_api)
         self.threat_events_fetcher: FetcherThreatEvents = FetcherThreatEvents(
@@ -185,9 +186,12 @@ class SentinelOneExpectationService:
         skipped_count = 0
 
         for expectation in expectations:
-            has_end_date = (
-                SignatureExtractor.extract_end_date([expectation]) is not None
-            )
+
+            has_end_date = True
+            if not self.disable_strict_end_date:
+                has_end_date = (
+                    SignatureExtractor.extract_end_date([expectation]) is not None
+                )
 
             if has_end_date:
                 valid_expectations.append(expectation)


### PR DESCRIPTION
### Proposed changes

* Adding a `disable_strict_end_date` optional configuration key to process expectations without an end date

### Testing Instructions

1. ?

### Related issues

* Closes #386 

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality