### PR TITLE
chore(renovate): emit Conventional Commits titles (#393)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":semanticCommits",
     "config:recommended"
   ],
   "labels": [


### PR DESCRIPTION
## Summary

Renovate now emits Conventional Commits titles (`chore(deps): ...`) instead of the old `[deps]` bracket prefix.

Closes #393