### PR TITLE
docs: improve PR title format hint in PR template and CONTRIBUTING.md (#413)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,14 @@ Thank you very much for your pull request to the OpenAEV project! We as a commun
 driven project depend on support and contributions like this!
 
 Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
+
+PR TITLE FORMAT (enforced by CI):
+  type(scope?)!?: description (#123)
+  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
+  - scope: optional, e.g. collector name (crowdstrike, sentinelone, …)
+  - description: must start with a lowercase letter
+  - (#123): required linked issue number
+  Example: feat(crowdstrike): add endpoint security import (#42)
 -->
 
 ### Proposed changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,15 @@ in [`.github/LABELS.md`](.github/LABELS.md). In short:
 
 * **Titles** — All commit, pull request and issue titles follow the
   [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-  specification with a GitHub issue reference:
-  `type(scope?)!?: description (#issue)` (e.g.
-  `feat(api): add bulk export endpoint (#1234)`). The description starts with a
-  lowercase letter and has no trailing period; preserve acronyms and proper
-  nouns. Types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`,
-  `test`, `build`, `ci`, `revert`.
+  specification with a GitHub issue reference. PR title format (enforced by CI):
+  ```
+  type(scope?)!?: description (#123)
+  ```
+  - **type**: one of `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`
+  - **scope**: optional — use the collector name or affected area (e.g. `crowdstrike`)
+  - **description**: must start with a lowercase letter, no trailing period; preserve acronyms and proper nouns
+  - **`(#123)`**: required — the linked issue number at the end
+  - Examples: `feat(crowdstrike): add endpoint security import (#42)`, `fix: resolve config loading issue (#99)`
 
 * **No more bracket prefixes** — The old `[backend]` / `[frontend]` /
   `[component]` prefixes are **discontinued**; use a Conventional Commits scope


### PR DESCRIPTION
## Summary

Port of the contributing documentation improvement from OpenCTI connectors (https://github.com/OpenCTI-Platform/connectors/commit/b3b61c0597951711e336a8caa4e126091187b7c1).

The CI already validates PR titles via `validate-pr-title.yml`, but contributors weren't given a clear reminder of the expected format. This PR surfaces it upfront.

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`**: add PR title format block inside the opening comment so it's visible before the contributor clears the template
- **`CONTRIBUTING.md`**: expand the "Titles" bullet in the conventions section with a code block, field-by-field breakdown, and examples

Closes #413