### PR TITLE
fix(test): bump pytest to ^9.0.0 in sentinelone, splunk-es and microsoft-defender (#416)

### DIFF
--- a/microsoft-defender/pyproject.toml
+++ b/microsoft-defender/pyproject.toml
@@ -19,7 +19,7 @@ msgraph-sdk = "1.40.0"
 msal = "1.33.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.5"
+pytest = "^9.0.0"
 
 [tool.poetry.extras]
 prod = ["pyoaev"]

--- a/sentinelone/pyproject.toml
+++ b/sentinelone/pyproject.toml
@@ -37,7 +37,7 @@ pip-audit = "^2.9.0"
 pre-commit = "^4.3.0"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^8.4.1"
+pytest = "^9.0.0"
 polyfactory = "^2.22.2"
 
 [project.scripts]

--- a/splunk-es/pyproject.toml
+++ b/splunk-es/pyproject.toml
@@ -37,7 +37,7 @@ pip-audit = "^2.9.0"
 pre-commit = "^4.3.0"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^8.4.1"
+pytest = "^9.0.0"
 polyfactory = "^2.22.2"
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Fixes #416

Bumps `pytest` from `^8.x` to `^9.0.0` in three collectors where CI tests were failing due to a dependency conflict.

## Root cause

The local `client-python` path (present in CI) requires `pytest >=9.0.0,<9.1.0`. Poetry resolves constraints across all extras, so the collectors' `^8.x` constraint caused version solving to fail entirely — preventing test group dependencies like `polyfactory` from being installed.

## Changes

- `sentinelone/pyproject.toml`: `^8.4.1` → `^9.0.0`
- `splunk-es/pyproject.toml`: `^8.4.1` → `^9.0.0`
- `microsoft-defender/pyproject.toml`: `^8.3.5` → `^9.0.0`