### PR TITLE
feat(asset): set asset category on collected endpoints (#446)

### DIFF
--- a/aws-resources/aws_resources/openaev_aws_resources.py
+++ b/aws-resources/aws_resources/openaev_aws_resources.py
@@ -299,6 +299,10 @@ class OpenAEVAWSResources(CollectorDaemon):
                     "endpoint_hostname": instance_name,
                     "endpoint_platform": platform,
                     "endpoint_arch": architecture,
+                    "asset_category": "HOST",
+                    "asset_cloud_provider": "AWS",
+                    "asset_cloud_native_type": "ec2_instance",
+                    "asset_cloud_region": region,
                     "endpoint_ips": ips,
                     "asset_description": f"AWS EC2 Instance - Type: {instance_type}, Region: {region}, AZ: {availability_zone}, State: {state}",
                 }

--- a/microsoft-azure/microsoft_azure/openaev_microsoft_azure.py
+++ b/microsoft-azure/microsoft_azure/openaev_microsoft_azure.py
@@ -294,6 +294,10 @@ class OpenAEVMicrosoftAzure(CollectorDaemon):
                         if "64" in vm_size or platform != "Generic"
                         else "Unknown"
                     ),
+                    "asset_category": "HOST",
+                    "asset_cloud_provider": "AZURE",
+                    "asset_cloud_native_type": "virtual_machine",
+                    "asset_cloud_region": vm_location,
                     "endpoint_ips": ips,
                     "asset_description": f"Azure VM - Size: {vm_size}, Location: {vm_location}",
                 }

--- a/microsoft-intune/microsoft_intune/openaev_microsoft_intune.py
+++ b/microsoft-intune/microsoft_intune/openaev_microsoft_intune.py
@@ -367,6 +367,11 @@ class OpenAEVMicrosoftIntune(CollectorDaemon):
                         f"Last Sync: {last_sync[:10]}"
                     )  # Just date part
 
+                # Mobile platforms map to the MOBILE_DEVICE asset category, everything else to HOST.
+                asset_category = (
+                    "MOBILE_DEVICE" if platform in ("iOS", "Android") else "HOST"
+                )
+
                 # Create endpoint object
                 endpoint = {
                     "asset_name": device_name,
@@ -374,6 +379,7 @@ class OpenAEVMicrosoftIntune(CollectorDaemon):
                     "endpoint_hostname": device.get("deviceName", device_name),
                     "endpoint_platform": platform,
                     "endpoint_arch": arch,
+                    "asset_category": asset_category,
                     "asset_description": ", ".join(description_parts),
                 }
 


### PR DESCRIPTION
### Proposed changes

* Cloud collectors (aws-resources, microsoft-azure, microsoft-intune) now set `asset_category` on the endpoints they create, so collected assets are classified in OpenAEV instead of being imported without a category.
* For cloud-hosted resources the collectors also populate the cloud context (`asset_cloud_provider`, `asset_cloud_native_type`, `asset_cloud_region`): aws-resources uses `HOST` / `AWS` / `ec2_instance` / instance region, and microsoft-azure uses `HOST` / `AZURE` / `virtual_machine` / VM location.
* microsoft-intune sets `asset_category` to `MOBILE_DEVICE` for iOS / Android devices and `HOST` otherwise; it does not set a cloud provider / native type / region because Intune devices are MDM-managed rather than cloud-hosted.

### Testing Instructions

1. Configure and run each collector (aws-resources, microsoft-azure, microsoft-intune) against an environment that exposes at least one asset.
2. In OpenAEV, verify the upserted endpoints carry the expected `asset_category`, and that AWS / Azure assets also carry the cloud provider, native type and region.
3. For Intune, confirm iOS / Android devices are categorised as `MOBILE_DEVICE` and all other platforms as `HOST`.

Note: these new endpoint fields require the server-side support delivered in OpenAEV-Platform/openaev#6452.

### Related issues

* Closes #446
* Depends on OpenAEV-Platform/openaev#6452

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

The change is intentionally minimal and additive. Collector endpoint payloads are loosely-typed dicts that the pyoaev `endpoint.upsert` helper forwards as-is to `/endpoints/agentless/upsert`, so the new fields are simply passed through to the platform (hence the dependency on the server-side PR above). These three collectors are the only ones in the repository that create endpoints, so the asset-category coverage is complete. Functional testing requires live AWS / Azure / Intune environments plus the server-side dependency, and these collectors do not yet have a unit-test harness, so no automated tests were added here; adding one - in particular to cover the Intune iOS / Android -> MOBILE_DEVICE mapping - is a sensible follow-up.
