### PR TITLE
fix(sentinelone): streamlining parent process search for threats (#415)

### DIFF
--- a/sentinelone/README.md
+++ b/sentinelone/README.md
@@ -40,7 +40,10 @@ links back to the originating SentinelOne threat.
 - A SentinelOne Management Console with API access
 - A SentinelOne API token with the `Threats` and `Threat Events` permissions (Deep Visibility and a Complete license are
   additionally required to validate static-engine detections)
+- An allowlisting SentinelOne-side of the OpenAEV agent (not the OpenAEV implant) and of the powershell used to start the implant/the executor*
 - For a manual (non-Docker) deployment: Python >= 3.11 and [Poetry](https://python-poetry.org/) >= 2.1
+
+* practical tip: a first run of an atomic testing can be used to flag the OpenAEV agent and the powershell process in SentinelOne, and then use the web interface of SentinelOne to flag them as false positive and to indicate they should run
 
 ## Configuration variables
 

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -1,6 +1,7 @@
 """SentinelOne Expectation Service with batch-based processing."""
 
 import logging
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any
 
@@ -73,6 +74,9 @@ class SentinelOneExpectationService:
         self.deep_visibility_fetcher: FetcherDeepVisibility = FetcherDeepVisibility(
             self.client_api
         )
+
+        self.failure_tracker: defaultdict = defaultdict(int)
+        self.max_failure = 5  # TODO
 
         self.logger.info(
             f"{LOG_PREFIX} Service initialized with batch size: {self.batch_size}"
@@ -325,6 +329,20 @@ class SentinelOneExpectationService:
             results = self._match_threats_to_expectations(
                 batch, threats, threat_events, detection_helper
             )
+
+            # TODO better
+            nope = []
+            for result in results:
+                if (
+                    not result.is_valid
+                    and self.failure_tracker[result.expectation_id] < self.max_failure
+                ):
+                    self.failure_tracker[result.expectation_id] += 1
+                    nope.append(result)
+                elif result.expectation_id in self.failure_tracker:
+                    del self.failure_tracker[result.expectation_id]
+
+            results = [result for result in results if not result in nope]
 
             return results
 

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -220,6 +220,43 @@ class SentinelOneExpectationService:
         )
         return batches, skipped_count
 
+    def _update_failures(
+        self, results: list[ExpectationResult]
+    ) -> list[ExpectationResult]:
+        """Update the failure tracker and return the relevant results for further process"""
+        retry_results = []
+        for result in results:
+            if (
+                not result.is_valid
+                and self.failure_tracker[result.expectation_id] < self.max_failure
+            ):
+                self.failure_tracker[result.expectation_id] += 1
+                retry_results.append(result)
+            elif result.expectation_id in self.failure_tracker:
+                self.failure_tracker.pop(result.expectation_id, None)
+
+        results = [result for result in results if not result in retry_results]
+        return results
+
+    def _update_date_in_case_of_failures(self, batch):
+        """Update the dates of a batch if a tracked failed expectation is found in it"""
+        now = datetime.now(timezone.utc)
+        if any(
+            str(expectation.inject_expectation_id) in self.failure_tracker
+            for expectation in batch
+        ):
+            for expectation in batch:
+                for signature in expectation.inject_expectation_signatures:
+                    if signature.type.value == "end_date":
+                        end_date = datetime.fromisoformat(
+                            signature.value.replace("Z", "+00:00")
+                        )
+                        if end_date < now:
+                            signature.value = str(now)
+                            self.logger.warning(
+                                f"end_date changed to {str(now)} for {expectation.inject_expectation_id}"
+                            )
+
     def _process_expectation_batch(
         self,
         batch: list[DetectionExpectation | PreventionExpectation],
@@ -238,22 +275,7 @@ class SentinelOneExpectationService:
 
         """
         try:
-            now = datetime.now(timezone.utc)
-            if any(
-                str(expectation.inject_expectation_id) in self.failure_tracker
-                for expectation in batch
-            ):
-                for expectation in batch:
-                    for signature in expectation.inject_expectation_signatures:
-                        if signature.type.value == "end_date":
-                            end_date = datetime.fromisoformat(
-                                signature.value.replace("Z", "+00:00")
-                            )
-                            if end_date < now:
-                                signature.value = str(now)
-                                self.logger.warning(
-                                    f"end_date changed to {str(now)} for {expectation.inject_expectation_id}"
-                                )
+            self._update_date_in_case_of_failures(batch)
 
             process_names = self._extract_process_names_from_batch(batch)
 
@@ -346,19 +368,7 @@ class SentinelOneExpectationService:
             results = self._match_threats_to_expectations(
                 batch, threats, threat_events, detection_helper
             )
-
-            retry_results = []
-            for result in results:
-                if (
-                    not result.is_valid
-                    and self.failure_tracker[result.expectation_id] < self.max_failure
-                ):
-                    self.failure_tracker[result.expectation_id] += 1
-                    retry_results.append(result)
-                elif result.expectation_id in self.failure_tracker:
-                    self.failure_tracker.pop(result.expectation_id, None)
-
-            results = [result for result in results if not result in retry_results]
+            results = self._update_failures(results)
 
             return results
 

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -76,7 +76,7 @@ class SentinelOneExpectationService:
         )
 
         self.failure_tracker: defaultdict = defaultdict(int)
-        self.max_failure = 5  # TODO
+        self.max_failure = 5
 
         self.logger.info(
             f"{LOG_PREFIX} Service initialized with batch size: {self.batch_size}"
@@ -238,6 +238,23 @@ class SentinelOneExpectationService:
 
         """
         try:
+            now = datetime.now(timezone.utc)
+            if any(
+                str(expectation.inject_expectation_id) in self.failure_tracker
+                for expectation in batch
+            ):
+                for expectation in batch:
+                    for signature in expectation.inject_expectation_signatures:
+                        if signature.type.value == "end_date":
+                            end_date = datetime.fromisoformat(
+                                signature.value.replace("Z", "+00:00")
+                            )
+                            if end_date < now:
+                                signature.value = str(now)
+                                self.logger.warning(
+                                    f"end_date changed to {str(now)} for {expectation.inject_expectation_id}"
+                                )
+
             process_names = self._extract_process_names_from_batch(batch)
 
             self.logger.debug(
@@ -249,14 +266,14 @@ class SentinelOneExpectationService:
                 f"{LOG_PREFIX} Batch {batch_idx}: Fetched {len(threats)} threats from time window"
             )
 
-            threat_events = {}
+            threat_events = defaultdict(list)
             for threat in threats:
                 try:
                     events = self.threat_events_fetcher.fetch_events_for_threat(
                         threat, process_names
                     )
                     if events:
-                        threat_events[threat.threat_id] = events
+                        threat_events[threat.threat_id].extend(events)
                         self.logger.debug(
                             f"{LOG_PREFIX} Batch {batch_idx}: threat {threat.threat_id} has {len(events)} threat events"
                         )
@@ -304,13 +321,13 @@ class SentinelOneExpectationService:
                             if sha1 in sha1_to_threat:
                                 threat = sha1_to_threat[sha1]
                                 if events:
-                                    threat_events[threat.threat_id] = events
+                                    threat_events[threat.threat_id].extend(events)
                                     self.logger.debug(
-                                        f"{LOG_PREFIX} Batch {batch_idx}: Static threat {threat.threat_id} has {len(events)} DV events"
+                                        f"{LOG_PREFIX} Batch {batch_idx}: threat {threat.threat_id} has {len(events)} DV events"
                                     )
                                 else:
                                     self.logger.debug(
-                                        f"{LOG_PREFIX} Batch {batch_idx}: Static threat {threat.threat_id} - no DV events found"
+                                        f"{LOG_PREFIX} Batch {batch_idx}: threat {threat.threat_id} - no DV events found"
                                     )
 
                         self.logger.info(
@@ -330,19 +347,18 @@ class SentinelOneExpectationService:
                 batch, threats, threat_events, detection_helper
             )
 
-            # TODO better
-            nope = []
+            retry_results = []
             for result in results:
                 if (
                     not result.is_valid
                     and self.failure_tracker[result.expectation_id] < self.max_failure
                 ):
                     self.failure_tracker[result.expectation_id] += 1
-                    nope.append(result)
+                    retry_results.append(result)
                 elif result.expectation_id in self.failure_tracker:
-                    del self.failure_tracker[result.expectation_id]
+                    self.failure_tracker.pop(result.expectation_id, None)
 
-            results = [result for result in results if not result in nope]
+            results = [result for result in results if not result in retry_results]
 
             return results
 
@@ -475,7 +491,6 @@ class SentinelOneExpectationService:
                         traces.append(trace)
 
                         if isinstance(expectation, PreventionExpectation):
-                            # breakpoint()
                             if threat.is_mitigated:
                                 matched = True
                                 self.logger.debug(
@@ -590,7 +605,6 @@ class SentinelOneExpectationService:
                 )
 
                 if oaev_implant_names:
-                    # breakpoint()
                     oaev_data["parent_process_name"] = {
                         "type": "fuzzy",
                         "data": oaev_implant_names,
@@ -640,7 +654,6 @@ class SentinelOneExpectationService:
                     f"{LOG_PREFIX} Detection helper input - filtered_data: {filtered_data}"
                 )
 
-                # breakpoint()
                 match_result = detection_helper.match_alert_elements(
                     signatures, filtered_data
                 )
@@ -661,7 +674,9 @@ class SentinelOneExpectationService:
             return True
 
         except Exception as e:
-            self.logger.warning(f"{LOG_PREFIX} Error in expectation matching: {e}")
+            self.logger.warning(
+                f"{LOG_PREFIX} Error in expectation matching: {type(e)} - {e}"
+            )
             return False
 
     def _create_error_result_object(

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -245,16 +245,8 @@ class SentinelOneExpectationService:
                 f"{LOG_PREFIX} Batch {batch_idx}: Fetched {len(threats)} threats from time window"
             )
 
-            static_threats = [threat for threat in threats if threat.is_static]
-            non_static_threats = [threat for threat in threats if not threat.is_static]
-
-            self.logger.debug(
-                f"{LOG_PREFIX} Batch {batch_idx}: Processing {len(static_threats)} static threats "
-                f"and {len(non_static_threats)} non-static threats"
-            )
-
             threat_events = {}
-            for threat in non_static_threats:
+            for threat in threats:
                 try:
                     events = self.threat_events_fetcher.fetch_events_for_threat(
                         threat, process_names
@@ -262,23 +254,23 @@ class SentinelOneExpectationService:
                     if events:
                         threat_events[threat.threat_id] = events
                         self.logger.debug(
-                            f"{LOG_PREFIX} Batch {batch_idx}: Non-static threat {threat.threat_id} has {len(events)} threat events"
+                            f"{LOG_PREFIX} Batch {batch_idx}: threat {threat.threat_id} has {len(events)} threat events"
                         )
                     else:
                         self.logger.debug(
-                            f"{LOG_PREFIX} Batch {batch_idx}: Non-static threat {threat.threat_id} - no threat events found"
+                            f"{LOG_PREFIX} Batch {batch_idx}: threat {threat.threat_id} - no threat events found"
                         )
                 except Exception as e:
                     self.logger.error(
-                        f"{LOG_PREFIX} Batch {batch_idx}: Error fetching threat events for non-static threat {threat.threat_id}: {e}"
+                        f"{LOG_PREFIX} Batch {batch_idx}: Error fetching threat events for threat {threat.threat_id}: {e}"
                     )
 
-            if static_threats and self.enable_deep_visibility_search:
+            if self.enable_deep_visibility_search:
                 try:
                     sha1_to_threat = {}
                     unique_sha1s = []
 
-                    for threat in static_threats:
+                    for threat in threats:
                         if threat.sha1:
                             if threat.sha1 not in sha1_to_threat:
                                 sha1_to_threat[threat.sha1] = threat
@@ -295,7 +287,7 @@ class SentinelOneExpectationService:
                         start_time = end_time - self.client_api.time_window
 
                         self.logger.debug(
-                            f"{LOG_PREFIX} Batch {batch_idx}: Fetching DV events for {len(unique_sha1s)} unique SHA1s (from {len(static_threats)} static threats) in single query for time window: {start_time} to {end_time}"
+                            f"{LOG_PREFIX} Batch {batch_idx}: Fetching DV events for {len(unique_sha1s)} unique SHA1s (from {len(threats)} threats) in single query for time window: {start_time} to {end_time}"
                         )
 
                         sha1_to_events = (
@@ -318,16 +310,16 @@ class SentinelOneExpectationService:
                                     )
 
                         self.logger.info(
-                            f"{LOG_PREFIX} Batch {batch_idx}: Processed {len(static_threats)} static threats with single DV query for {len(unique_sha1s)} unique SHA1s"
+                            f"{LOG_PREFIX} Batch {batch_idx}: Processed {len(threats)} threats with single DV query for {len(unique_sha1s)} unique SHA1s"
                         )
                     else:
                         self.logger.debug(
-                            f"{LOG_PREFIX} Batch {batch_idx}: No valid SHA1s found for static threats"
+                            f"{LOG_PREFIX} Batch {batch_idx}: No valid SHA1s found for threats"
                         )
 
                 except Exception as e:
                     self.logger.error(
-                        f"{LOG_PREFIX} Batch {batch_idx}: Error fetching DV events for static threats batch: {e}"
+                        f"{LOG_PREFIX} Batch {batch_idx}: Error fetching DV events for threats batch: {e}"
                     )
 
             results = self._match_threats_to_expectations(
@@ -545,28 +537,38 @@ class SentinelOneExpectationService:
             oaev_data = oaev_data_list[0]
 
             if events:
-                if threat.is_static:
-                    parent_process_names = (
-                        SentinelOneThreat.get_parent_process_name_from_dv_events(events)
-                    )
-                else:
-                    parent_process_names = (
-                        SentinelOneThreat.get_parent_process_name_from_events(events)
-                    )
-                oaev_implant_names = [
+                dv_parent_process_names = (
+                    SentinelOneThreat.get_parent_process_name_from_dv_events(events)
+                )
+                dv_oaev_implant_names = [
                     name
-                    for name in parent_process_names
+                    for name in dv_parent_process_names
                     if name.startswith("oaev-implant-")
                 ]
+                self.logger.debug(
+                    f"{LOG_PREFIX} Threat {threat.threat_id}: Found {len(dv_parent_process_names)} "
+                    f"process names from DV events (parentProcessName + processName), {len(dv_oaev_implant_names)} with oaev-implant- prefix"
+                )
 
-                if threat.is_static:
-                    event_source = "DV events (parentProcessName + processName)"
-                else:
-                    event_source = "threat events"
+                classic_parent_process_names = (
+                    SentinelOneThreat.get_parent_process_name_from_events(events)
+                )
+                classic_oaev_implant_names = [
+                    name
+                    for name in classic_parent_process_names
+                    if name.startswith("oaev-implant-")
+                ]
+                self.logger.debug(
+                    f"{LOG_PREFIX} Threat {threat.threat_id}: Found {len(classic_parent_process_names)} "
+                    f"process names from threat events, {len(classic_oaev_implant_names)} with oaev-implant- prefix"
+                )
+
+                oaev_implant_names = list(
+                    set(dv_oaev_implant_names + classic_oaev_implant_names)
+                )
 
                 self.logger.debug(
-                    f"{LOG_PREFIX} Threat {threat.threat_id}: Found {len(parent_process_names)} "
-                    f"process names from {event_source}, {len(oaev_implant_names)} with oaev-implant- prefix"
+                    f"{LOG_PREFIX} Threat {threat.threat_id}: Found a total of {len(oaev_implant_names)} unique processes with oaev-implant- prefix"
                 )
 
                 if oaev_implant_names:

--- a/sentinelone/src/services/fetcher_deep_visibility.py
+++ b/sentinelone/src/services/fetcher_deep_visibility.py
@@ -1,4 +1,4 @@
-"""SentinelOne Deep Visibility Fetcher for static threat analysis."""
+"""SentinelOne Deep Visibility Fetcher for threat analysis."""
 
 import logging
 import re
@@ -21,7 +21,7 @@ MAX_STATUS_POLL_ATTEMPTS = 30
 
 
 class FetcherDeepVisibility:
-    """Fetcher for SentinelOne Deep Visibility data for static threats."""
+    """Fetcher for SentinelOne Deep Visibility data for threats."""
 
     def __init__(self, client_api: SentinelOneClientAPI):
         """Initialize the Deep Visibility fetcher.

--- a/sentinelone/tests/unit/services/test_expectation_service.py
+++ b/sentinelone/tests/unit/services/test_expectation_service.py
@@ -1,0 +1,218 @@
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+from uuid import UUID
+
+import src.services.expectation_service as module
+
+
+@patch.object(module, "FetcherDeepVisibility")
+@patch.object(module, "FetcherThreatEvents")
+@patch.object(module, "FetcherThreat")
+@patch.object(module, "SentinelOneConverter")
+@patch.object(module, "SentinelOneClientAPI")
+class TestSentinelOneExpectationService(unittest.TestCase):
+    def test_init(
+        self,
+        m_api,
+        m_converter,
+        m_fetcher_threat,
+        m_fetcher_threat_events,
+        m_fetcher_deep_visibility,
+    ):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+
+        self.assertEqual(service.client_api, m_api.return_value)
+        self.assertEqual(service.converter, m_converter.return_value)
+        self.assertEqual(service.batch_size, config.sentinelone.expectation_batch_size)
+        self.assertEqual(
+            service.enable_deep_visibility_search,
+            config.sentinelone.enable_deep_visibility_search,
+        )
+        self.assertEqual(
+            service.disable_strict_end_date, config.sentinelone.disable_strict_end_date
+        )
+        self.assertEqual(service.threat_fetcher, m_fetcher_threat.return_value)
+        self.assertEqual(
+            service.threat_events_fetcher, m_fetcher_threat_events.return_value
+        )
+        self.assertEqual(
+            service.deep_visibility_fetcher, m_fetcher_deep_visibility.return_value
+        )
+        self.assertIsInstance(service.failure_tracker, module.defaultdict)
+        self.assertEqual(service.max_failure, 5)
+        m_api.assert_called_once_with(config)
+        m_converter.assert_called_once()
+        m_fetcher_threat.assert_called_once_with(m_api.return_value)
+        m_fetcher_threat_events.assert_called_once_with(m_api.return_value)
+        m_fetcher_deep_visibility.assert_called_once_with(m_api.return_value)
+
+    def test_get_supported_signatures(self, *_):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+
+        self.assertEqual(
+            service.get_supported_signatures(),
+            [
+                module.SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
+                module.SignatureTypes.SIG_TYPE_TARGET_HOSTNAME_ADDRESS,
+                module.SignatureTypes.SIG_TYPE_END_DATE,
+            ],
+        )
+
+    @patch.object(module.SentinelOneExpectationService, "_process_expectation_batch")
+    @patch.object(module.SentinelOneExpectationService, "_create_expectation_batches")
+    def test_handle_batch_expectations(
+        self, m_create_expectation_batches, m_process_expectation_batch, *_
+    ):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+
+        expectations = MagicMock()
+        detection_helper = MagicMock()
+        batch = MagicMock()
+        batches = [batch]
+        m_create_expectation_batches.return_value = batches, 0
+        batch_results = [MagicMock()]
+        m_process_expectation_batch.return_value = batch_results
+
+        all_results, skipped_count = service.handle_batch_expectations(
+            expectations, detection_helper
+        )
+
+        m_create_expectation_batches.assert_called_once_with(expectations)
+        m_process_expectation_batch.assert_called_with(batch, detection_helper, 1)
+        self.assertEqual(all_results, batch_results)
+
+    @patch.object(module, "SignatureExtractor")
+    def test_create_expectation_batches(self, m_signature_extractor, *_):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.disable_strict_end_date = False
+
+        expectation_zero = MagicMock()
+        expectations = [expectation_zero]
+        m_signature_extractor.extract_end_date.return_value = 1
+
+        batches, skipped_count = service._create_expectation_batches(expectations)
+
+        m_signature_extractor.extract_end_date.assert_called_once_with(
+            [expectation_zero]
+        )
+        self.assertEqual(batches, [[expectation_zero]])
+
+    def test_update_failures(self, *_):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+
+        uuid_zero = "6b7d53b5-2828-4be8-a797-a5193c615ec5"
+        result_zero = MagicMock()
+        result_zero.is_valid = True
+        result_zero.expectation_id = uuid_zero
+
+        uuid_one = "2930a07a-7077-478b-a7d0-27699a03edf3"
+        result_one = MagicMock()
+        result_one.is_valid = False
+        result_one.expectation_id = uuid_one
+        service.failure_tracker[uuid_one] = 2
+
+        uuid_two = "adccb725-9769-4856-bbc3-1cdc1ff98a26"
+        result_two = MagicMock()
+        result_two.is_valid = False
+        result_two.expectation_id = uuid_two
+        service.failure_tracker[uuid_two] = 5
+
+        m_results = [result_zero, result_one, result_two]
+
+        results = service._update_failures(m_results)
+
+        self.assertNotEqual(len(m_results), len(results))
+        self.assertEqual(len(results), 2)
+        self.assertEqual(service.failure_tracker[uuid_one], 3)
+        self.assertNotIn(uuid_two, service.failure_tracker)
+        self.assertNotIn(uuid_zero, service.failure_tracker)
+
+    def test_update_date_in_case_of_failures(self, *_):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+
+        uuid = UUID("feb4be6f-72c7-4212-8984-a7d7c42178f0")
+        service.failure_tracker[str(uuid)] = 1
+
+        expectation = MagicMock()
+        expectation.inject_expectation_id = uuid
+        signature_type = MagicMock()
+        signature_type.value = "end_date"
+        signature_value = "2026-05-04 03:02:01.425813Z"
+        signature = MagicMock()
+        signature.type = signature_type
+        signature.value = signature_value
+        expectation.inject_expectation_signatures = [signature]
+
+        batch = [expectation]
+
+        service._update_date_in_case_of_failures(batch)
+
+        self.assertNotEqual(signature.value, signature_value)
+
+    @patch.object(module.SentinelOneExpectationService, "_update_failures")
+    @patch.object(
+        module.SentinelOneExpectationService, "_match_threats_to_expectations"
+    )
+    @patch.object(
+        module.SentinelOneExpectationService, "_fetch_threats_for_time_window"
+    )
+    @patch.object(
+        module.SentinelOneExpectationService, "_extract_process_names_from_batch"
+    )
+    @patch.object(
+        module.SentinelOneExpectationService, "_update_date_in_case_of_failures"
+    )
+    def test_process_expectation_batch(
+        self,
+        m_update_date_in_case_of_failures,
+        m_extract_process_names_from_batch,
+        m_fetch_threats_for_time_window,
+        m_match_threats_to_expectations,
+        m_update_failures,
+        m_api,
+        m_converter,
+        m_fetcher_threat,
+        m_fetcher_threat_events,
+        m_fetcher_deep_visibility,
+    ):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+
+        expectation = MagicMock()
+        batch = [expectation]
+        detection_helper = MagicMock()
+        batch_idx = 1
+        threat = MagicMock()
+        threats = [threat]
+        m_fetch_threats_for_time_window.return_value = threats
+        m_result = MagicMock()
+        m_results = [m_result]
+        m_match_threats_to_expectations.return_value = m_results
+        m_updated_results = [m_result]
+        m_update_failures.return_value = m_updated_results
+
+        results = service._process_expectation_batch(batch, detection_helper, batch_idx)
+
+        m_extract_process_names_from_batch.assert_called_once_with(batch)
+        m_fetch_threats_for_time_window.assert_called_once_with(batch)
+        m_fetcher_threat_events.return_value.fetch_events_for_threat.assert_called_once_with(
+            threat, m_extract_process_names_from_batch.return_value
+        )
+        m_match_threats_to_expectations.assert_called_once_with(
+            batch, threats, ANY, detection_helper
+        )
+        m_update_failures.assert_called_once_with(m_results)
+        self.assertEqual(results, m_updated_results)


### PR DESCRIPTION
### Proposed changes

* Using both classic and deepvision-based parent process search for both static and non-static threats
* Add a retry system keeping track of failed expectations inside the collector in order to handle timestamp drift

### Testing Instructions

1. Setup an environment with an OpenAEV, the atomic red team collector, an OpenAEV agent, an access to S1 and an S1 agent
2. Start the S1 collector from this branch configured to connect to both the OpenAEV and S1 mentionned above
3. Run "SharpHound3 - LocalAdmin" as an atomic test from OpenAEV targeting the station with the OpenAEV agent and the S1 agent
4. Check that `SharpHound.exe` is detected and prevented by S1 (note: you may need to allowlist the OpenAEV agent beforehands, verify which software raised the alert in S1)
5. Wait for the atomic testing webUI to indicate proper detection and prevention by S1 in the results

### Related issues

* Closes #415 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
