### PR TITLE
fix(atomic-red-team): _configuration instead of config (#466)

### DIFF
--- a/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
+++ b/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
@@ -157,10 +157,10 @@ def _format_command(string_to_analyse, arguments, platforms, prerequisites):
     def handle_match_callback(string, match):
         if os.path.basename(match) == "ExternalPayloads":
             return string
-        else:
-            arg_name = get_argument_name_by_path(arguments, match)
-            handle_resources(platforms, prerequisites, match, arg_name)
-            return string.replace(match, f"#{{{arg_name}}}")
+
+        arg_name = get_argument_name_by_path(arguments, match)
+        handle_resources(platforms, prerequisites, match, arg_name)
+        return string.replace(match, f"#{{{arg_name}}}")
 
     return _catch_atomic_folder_paths(string_to_analyse, handle_match_callback)
 
@@ -174,9 +174,9 @@ def _format_prerequisite(string_to_analyse, arguments):
         if os.path.basename(match) == "ExternalPayloads":
             folder_name = match
             return string
-        else:
-            arg_name = get_argument_name_by_path(arguments, match)
-            return string.replace(match, f"#{{{arg_name}}}")
+
+        arg_name = get_argument_name_by_path(arguments, match)
+        return string.replace(match, f"#{{{arg_name}}}")
 
     string_to_analyse = _catch_atomic_folder_paths(
         string_to_analyse, handle_match_callback
@@ -394,7 +394,7 @@ class OpenAEVAtomicRedTeam(CollectorDaemon):
                         payload_external_ids.append(payload["payload_external_id"])
         self.api.payload.deprecate(
             {
-                "collector_id": self.config.get("collector_id"),
+                "collector_id": self._configuration.get("collector_id"),
                 "payload_external_ids": payload_external_ids,
             }
         )


### PR DESCRIPTION
### Proposed changes

* `_configuration` instead of `config`
* Plus, withdrawing unnecessary else after return

### Testing Instructions

1. Run an atomic testing using atomic red team

### Related issues

* Closes #466 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
