### PR TITLE
feat(microsoft-defender-o365): mvp1/chk5 - register expectation signature types (#499)

### DIFF
--- a/microsoft-defender-o365/src/source/microsoft_defender_o365_signatures.py
+++ b/microsoft-defender-o365/src/source/microsoft_defender_o365_signatures.py
@@ -1,5 +1,12 @@
 from pyoaev.signatures.types import SignatureTypes  # noqa: F401
 
-# No signature definitions in this chunk (#471 - project architecture setup).
-# Signatures will be added once the actual data collection logic is implemented.
-SUPPORTED_SIGNATURES: list[SignatureTypes] = []
+
+SUPPORTED_SIGNATURES: list[SignatureTypes] = [
+    SignatureTypes.SIG_TYPE_START_DATE,
+    SignatureTypes.SIG_TYPE_END_DATE,
+    SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
+    SignatureTypes.SIG_TYPE_URL_HASH,
+    SignatureTypes.SIG_TYPE_FILE_HASH,
+    SignatureTypes.SIG_TYPE_SOURCE_EMAIL,
+    SignatureTypes.SIG_TYPE_TARGET_EMAIL,
+]

--- a/microsoft-defender-o365/src/source/microsoft_defender_o365_signatures.py
+++ b/microsoft-defender-o365/src/source/microsoft_defender_o365_signatures.py
@@ -1,6 +1,5 @@
 from pyoaev.signatures.types import SignatureTypes  # noqa: F401
 
-
 SUPPORTED_SIGNATURES: list[SignatureTypes] = [
     SignatureTypes.SIG_TYPE_START_DATE,
     SignatureTypes.SIG_TYPE_END_DATE,

--- a/microsoft-defender-o365/src/source/microsoft_defender_o365_signatures.py
+++ b/microsoft-defender-o365/src/source/microsoft_defender_o365_signatures.py
@@ -9,4 +9,5 @@ SUPPORTED_SIGNATURES: list[SignatureTypes] = [
     SignatureTypes.SIG_TYPE_FILE_HASH,
     SignatureTypes.SIG_TYPE_SOURCE_EMAIL,
     SignatureTypes.SIG_TYPE_TARGET_EMAIL,
+    SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER,
 ]

--- a/microsoft-defender-o365/tests/features/test_container_startup.py
+++ b/microsoft-defender-o365/tests/features/test_container_startup.py
@@ -1,9 +1,9 @@
 """Essential tests for Microsoft Defender O365 container startup - Gherkin GWT Format."""
 
 from unittest.mock import MagicMock, patch
-from pytest import FixtureRequest
 
 import pytest
+from pytest import FixtureRequest
 
 # --------
 # Scenarios

--- a/microsoft-defender-o365/tests/unit/source/test_signatures.py
+++ b/microsoft-defender-o365/tests/unit/source/test_signatures.py
@@ -7,7 +7,7 @@ class TestSignatures(unittest.TestCase):
     def test_length(self):
         self.assertEqual(
             len(module.SUPPORTED_SIGNATURES),
-            7,
+            8,
         )
 
     def test_types(self):

--- a/microsoft-defender-o365/tests/unit/source/test_signatures.py
+++ b/microsoft-defender-o365/tests/unit/source/test_signatures.py
@@ -1,0 +1,22 @@
+import unittest
+
+import src.source.microsoft_defender_o365_signatures as module
+
+
+class TestSignatures(unittest.TestCase):
+    def test_length(self):
+        self.assertEqual(
+            len(module.SUPPORTED_SIGNATURES),
+            7,
+        )
+
+    def test_types(self):
+        for sig in module.SUPPORTED_SIGNATURES:
+            self.assertIsInstance(sig, module.SignatureTypes)
+
+    def test_no_duplicate(self):
+        for sig in module.SUPPORTED_SIGNATURES:
+            self.assertEqual(
+                module.SUPPORTED_SIGNATURES.count(sig),
+                1,
+            )


### PR DESCRIPTION
Parent Issue: #499
Parent PR (MVP): #492

## Contracts

### Input Contract

7 total signature types must exist in or be contributable to the enum (3 standard types + 4 email placeholders waiting for the injector).

### Output Contract

```python
from pyoaev.signatures.types import SignatureTypes

SUPPORTED_SIGNATURES: list[SignatureTypes] = [
    # Standard signatures (from template)
    SignatureTypes.SIG_TYPE_START_DATE,
    SignatureTypes.SIG_TYPE_END_DATE,
    SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
    # Email-specific signatures (placeholder names — final names defined by injector)
    SignatureTypes.SIG_TYPE_MAIL_SOURCE_EMAIL,
    SignatureTypes.SIG_TYPE_MAIL_PLAYER_EMAIL,
    SignatureTypes.SIG_TYPE_MAIL_URL_HASH,
    SignatureTypes.SIG_TYPE_MAIL_ATTACHMENT_HASH,
]
```

Consumed by: `Source(signatures=SUPPORTED_SIGNATURES)` in the collector entry point (CHK.1 scaffold).

## Acceptance Criteria

```gherkin
@signatures @oaev @microsoft-defender-o365

Feature: SUPPORTED_SIGNATURES declares all email-relevant signature types
  As a collector developer
  I want a canonical list of supported signature types
  So that the platform knows which expectation fields this collector can match against

  Scenario Outline: SUPPORTED_SIGNATURES contains each expected type
    When SUPPORTED_SIGNATURES is set
    Then the list contains <signature_type>

    Examples:
      | signature_type          |
      | SIG_TYPE_START_DATE     |
      | SIG_TYPE_END_DATE       |
      | SIG_TYPE_EMAIL_SUBJECT  |
      | SIG_TYPE_SENDER_DOMAIN  |
      | SIG_TYPE_SENDER_ADDRESS |
      | SIG_TYPE_THREAT_TYPE    |

  Scenario Outline: SUPPORTED_SIGNATURES contains no duplicate entries
    When SUPPORTED_SIGNATURES is set
    Then len(SUPPORTED_SIGNATURES) equals len(set(SUPPORTED_SIGNATURES))

    Examples:
      | expected_count |
      | 6              |

  Scenario Outline: get_expectation_signature_groups returns SUPPORTED_SIGNATURES
    Given a DefenderO365Collector instance
    When get_expectation_signature_groups is called
    Then the returned list equals SUPPORTED_SIGNATURES

    Examples:
      | method_name                      |
      | get_expectation_signature_groups |
```

## Done Checklist

- [x]  Create `src/source/defender_o365_signatures.py` with `SUPPORTED_SIGNATURES`
- [x]  Populate with 7 `SignatureTypes` values (3 standard + 4 email placeholders)
- [x]  Write unit tests: all 7 types present, no duplicates, all are valid `SignatureTypes`
- [ ]  Create a dedicated PR linked to the Umbrella issue

Closes #499
