### PR TITLE
feat(microsoft-defender-o365): mvp1/chk8 - matching integration between expectations and oaevdata (#505)

### DIFF
--- a/microsoft-defender-o365/tests/conftest.py
+++ b/microsoft-defender-o365/tests/conftest.py
@@ -12,6 +12,11 @@ from unittest.mock import MagicMock
 import pytest
 from polyfactory.factories.pydantic_factory import ModelFactory
 from pydantic import BaseModel
+from pyoaev.apis.inject_expectation.model.expectation import (
+    DetectionExpectation,
+    ExpectationSignature,
+    PreventionExpectation,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -811,7 +816,7 @@ def _chunk8_state_isolation():
 
 def _given_detection_expectation_with_supported_sigs(
     exp_id: str = "exp-001",
-) -> "DetectionExpectation":
+) -> DetectionExpectation:
     """Given a DetectionExpectation with signatures matching the 5 supported types.
 
     Args:
@@ -822,10 +827,6 @@ def _given_detection_expectation_with_supported_sigs(
     """
     import uuid
 
-    from pyoaev.apis.inject_expectation.model.expectation import (
-        DetectionExpectation,
-        ExpectationSignature,
-    )
     from src.source.signatures import SUPPORTED_SIGNATURES
 
     return DetectionExpectation(
@@ -841,7 +842,7 @@ def _given_detection_expectation_with_supported_sigs(
     )
 
 
-def _given_prevention_expectation_with_supported_sigs() -> "PreventionExpectation":
+def _given_prevention_expectation_with_supported_sigs() -> PreventionExpectation:
     """Given a PreventionExpectation with signatures matching the 5 supported types.
 
     Returns:
@@ -849,10 +850,6 @@ def _given_prevention_expectation_with_supported_sigs() -> "PreventionExpectatio
     """
     import uuid
 
-    from pyoaev.apis.inject_expectation.model.expectation import (
-        ExpectationSignature,
-        PreventionExpectation,
-    )
     from src.source.signatures import SUPPORTED_SIGNATURES
 
     return PreventionExpectation(
@@ -868,7 +865,7 @@ def _given_prevention_expectation_with_supported_sigs() -> "PreventionExpectatio
     )
 
 
-def _given_expectation_with_unsupported_sigs() -> "DetectionExpectation":
+def _given_expectation_with_unsupported_sigs() -> DetectionExpectation:
     """Given an expectation with signatures including types NOT in SUPPORTED_SIGNATURES.
 
     Returns:
@@ -890,10 +887,7 @@ def _given_expectation_with_unsupported_sigs() -> "DetectionExpectation":
     sigs = [
         ExpectationSignature(type=sig_type, value=_sig_test_value_for_type(sig_type))
         for sig_type in SUPPORTED_SIGNATURES
-    ] + [
-        ExpectationSignature(type=t, value="unsupported-value")
-        for t in extra_types
-    ]
+    ] + [ExpectationSignature(type=t, value="unsupported-value") for t in extra_types]
 
     return DetectionExpectation(
         inject_expectation_id=uuid.uuid4(),
@@ -944,9 +938,7 @@ def _given_matching_alert_data(
         },
         SignatureTypes.SIG_TYPE_URL_HASH.value: {
             "type": "simple",
-            "data": [
-                "6e828dac1a6b547942ad393d0e3b5e37e50e974a86c8c61e5b77e6a0c7b7c6d"
-            ],
+            "data": ["6e828dac1a6b547942ad393d0e3b5e37e50e974a86c8c61e5b77e6a0c7b7c6d"],
         },
         SignatureTypes.SIG_TYPE_FILE_HASH.value: {
             "type": "simple",
@@ -1071,13 +1063,9 @@ def _when_engine_processes_batch(
     Returns:
         List of ExpectationResult objects.
     """
-    from unittest.mock import MagicMock, patch
-
     from pyoaev.helpers import OpenAEVDetectionHelper
     from src.collector.engines.basic import BasicCollectorEngine
-    from src.collector.models.data import OAEVData
     from src.collector.models.source import SourceHandler
-    from src.collector.protocols.data_fetcher import DataFetcherProtocol
     from src.models.settings.source_configs import _ConfigLoaderSource
     from src.source.signatures import SUPPORTED_SIGNATURES
 
@@ -1090,12 +1078,12 @@ def _when_engine_processes_batch(
         data = alert_data if alert_data else _CHUNK8_STATE.get("fetch_result", [])
 
     # Build signature groups for matching
-    sig_groups = SourceHandler.get_expectation_signature_groups(
+    SourceHandler.get_expectation_signature_groups(
         SUPPORTED_SIGNATURES, expectations[0]
     )
 
     # Detection helper that matches based on sig groups
-    helper = OpenAEVDetectionHelper(
+    OpenAEVDetectionHelper(
         logger=MagicMock(),
         relevant_signatures_types=SUPPORTED_SIGNATURES,
     )
@@ -1134,9 +1122,7 @@ def _when_engine_processes_batch(
 
     # Simple data fetcher class to avoid auth during test
     class MockDataFetcher(DefenderO365DataFetcher):
-        def __init__(
-            self, config, fetch_params_hook=None
-        ):
+        def __init__(self, config, fetch_params_hook=None):
             self.config = config
             self._fetch_params_hook = fetch_params_hook
 
@@ -1221,7 +1207,6 @@ def _then_only_supported_sigs_retained(sig_groups: dict) -> None:
     Args:
         sig_groups: The filtered signature groups dict.
     """
-    from pyoaev.signatures.types import SignatureTypes
     from src.source.signatures import SUPPORTED_SIGNATURES
 
     supported_values = {sig.value for sig in SUPPORTED_SIGNATURES}

--- a/microsoft-defender-o365/tests/conftest.py
+++ b/microsoft-defender-o365/tests/conftest.py
@@ -786,3 +786,496 @@ def _then_oaev_data_contains_hashes_from_both_urls(oaev_data, urls: list[str]) -
         md5 = hashlib.md5(url.encode("utf-8")).hexdigest()
         for digest in (sha256, sha1, md5):
             assert digest in actual, f"Expected {digest} in {actual}"
+
+
+# --------
+# Chunk8 (#505) - Matching integration GWT helpers
+# --------
+
+#: Module-level state to control fetcher behaviour across test scenarios
+_CHUNK8_STATE: dict[str, object] = {}
+
+
+def _reset_chunk8_state() -> None:
+    """Clear chunk8 test state before each scenario."""
+    _CHUNK8_STATE.clear()
+
+
+@pytest.fixture(autouse=True)
+def _chunk8_state_isolation():
+    """Ensure chunk8 state is clean before and after each test."""
+    _reset_chunk8_state()
+    yield
+    _reset_chunk8_state()
+
+
+def _given_detection_expectation_with_supported_sigs(
+    exp_id: str = "exp-001",
+) -> "DetectionExpectation":
+    """Given a DetectionExpectation with signatures matching the 5 supported types.
+
+    Args:
+        exp_id: The expectation identifier.
+
+    Returns:
+        A DetectionExpectation instance with signatures for each supported type.
+    """
+    import uuid
+
+    from pyoaev.apis.inject_expectation.model.expectation import (
+        DetectionExpectation,
+        ExpectationSignature,
+    )
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    return DetectionExpectation(
+        inject_expectation_id=uuid.uuid4(),
+        inject_expectation_signatures=[
+            ExpectationSignature(
+                type=sig_type,
+                value=_sig_test_value_for_type(sig_type),
+            )
+            for sig_type in SUPPORTED_SIGNATURES
+        ],
+        api_client=None,
+    )
+
+
+def _given_prevention_expectation_with_supported_sigs() -> "PreventionExpectation":
+    """Given a PreventionExpectation with signatures matching the 5 supported types.
+
+    Returns:
+        A PreventionExpectation instance with signatures for each supported type.
+    """
+    import uuid
+
+    from pyoaev.apis.inject_expectation.model.expectation import (
+        ExpectationSignature,
+        PreventionExpectation,
+    )
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    return PreventionExpectation(
+        inject_expectation_id=uuid.uuid4(),
+        inject_expectation_signatures=[
+            ExpectationSignature(
+                type=sig_type,
+                value=_sig_test_value_for_type(sig_type),
+            )
+            for sig_type in SUPPORTED_SIGNATURES
+        ],
+        api_client=None,
+    )
+
+
+def _given_expectation_with_unsupported_sigs() -> "DetectionExpectation":
+    """Given an expectation with signatures including types NOT in SUPPORTED_SIGNATURES.
+
+    Returns:
+        A DetectionExpectation with both supported and unsupported signature types.
+    """
+    import uuid
+
+    from pyoaev.apis.inject_expectation.model.expectation import (
+        DetectionExpectation,
+        ExpectationSignature,
+    )
+    from pyoaev.signatures.types import SignatureTypes
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    # Add a signature type not in SUPPORTED_SIGNATURES
+    all_types = list(SignatureTypes)
+    extra_types = [t for t in all_types if t not in SUPPORTED_SIGNATURES][:2]
+
+    sigs = [
+        ExpectationSignature(type=sig_type, value=_sig_test_value_for_type(sig_type))
+        for sig_type in SUPPORTED_SIGNATURES
+    ] + [
+        ExpectationSignature(type=t, value="unsupported-value")
+        for t in extra_types
+    ]
+
+    return DetectionExpectation(
+        inject_expectation_id=uuid.uuid4(),
+        inject_expectation_signatures=sigs,
+        api_client=None,
+    )
+
+
+def _given_matching_alert_data(
+    prevention: bool = False,
+) -> list:
+    """Given source data producing OAEVData with matching values and correct detection.
+
+    Builds mock MicrosoftDefenderO365SourceData objects whose to_oaev_data()
+    returns values that match the expectation signatures, and whose
+    is_detected() / is_prevented() return the correct flag.
+
+    Args:
+        prevention: If True, is_prevented() returns True instead of is_detected().
+
+    Returns:
+        A list containing one mock source data object.
+    """
+    from unittest.mock import MagicMock
+
+    from pyoaev.signatures.types import SignatureTypes
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    mock_sd = MagicMock()
+    oaev_data = MagicMock()
+
+    # to_oaev_data returns an OAEVData-like object with matching values
+    def to_oaev_data():
+        return oaev_data
+
+    mock_sd.to_oaev_data = to_oaev_data
+
+    # Set attribute access to return matching values in the structure
+    # expected by OpenAEVDetectionHelper.match_alert_elements
+    sig_values = {
+        SignatureTypes.SIG_TYPE_SOURCE_EMAIL.value: {
+            "type": "simple",
+            "data": ["bad@evil.com"],
+        },
+        SignatureTypes.SIG_TYPE_TARGET_EMAIL.value: {
+            "type": "simple",
+            "data": ["victim@corp.com"],
+        },
+        SignatureTypes.SIG_TYPE_URL_HASH.value: {
+            "type": "simple",
+            "data": [
+                "6e828dac1a6b547942ad393d0e3b5e37e50e974a86c8c61e5b77e6a0c7b7c6d"
+            ],
+        },
+        SignatureTypes.SIG_TYPE_FILE_HASH.value: {
+            "type": "simple",
+            "data": ["abc123"],
+        },
+        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER.value: {
+            "type": "simple",
+            "data": ["header-val"],
+        },
+    }
+    oaev_data.model_dump.return_value = sig_values
+    for sig_type in SUPPORTED_SIGNATURES:
+        setattr(oaev_data, sig_type.value, sig_values[sig_type.value])
+
+    # Detection / prevention flags
+    mock_sd.is_detected.return_value = not prevention
+    mock_sd.is_prevented.return_value = prevention
+
+    # Trace data serialization
+    mock_trace = MagicMock()
+    mock_trace.model_dump.return_value = {
+        "alert_name": "Test Alert",
+        "alert_link": "https://security.microsoft.com/alerts/ALT-001",
+        "alert_date": "2026-07-01T08:00:00Z",
+    }
+    mock_sd.to_traces_data.return_value = mock_trace
+
+    return [mock_sd]
+
+
+def _given_non_matching_alert_data() -> list:
+    """Given source data producing OAEVData with non-matching values.
+
+    Returns:
+        A list containing one mock source data object with different values.
+    """
+    from unittest.mock import MagicMock
+
+    from pyoaev.signatures.types import SignatureTypes
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    mock_sd = MagicMock()
+    oaev_data = MagicMock()
+
+    def to_oaev_data():
+        return oaev_data
+
+    mock_sd.to_oaev_data = to_oaev_data
+
+    # Values that won't match expectation signatures
+    sig_values = {
+        SignatureTypes.SIG_TYPE_SOURCE_EMAIL.value: {
+            "type": "simple",
+            "data": ["other@evil.com"],
+        },
+        SignatureTypes.SIG_TYPE_TARGET_EMAIL.value: {
+            "type": "simple",
+            "data": ["boss@corp.com"],
+        },
+        SignatureTypes.SIG_TYPE_URL_HASH.value: {
+            "type": "simple",
+            "data": [
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            ],
+        },
+        SignatureTypes.SIG_TYPE_FILE_HASH.value: {
+            "type": "simple",
+            "data": ["xyz789"],
+        },
+        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER.value: {
+            "type": "simple",
+            "data": ["other-header"],
+        },
+    }
+    oaev_data.model_dump.return_value = sig_values
+    for sig_type in SUPPORTED_SIGNATURES:
+        setattr(oaev_data, sig_type.value, sig_values[sig_type.value])
+
+    mock_sd.is_detected.return_value = True
+    mock_sd.is_prevented.return_value = False
+
+    mock_trace = MagicMock()
+    mock_trace.model_dump.return_value = {
+        "alert_name": "Test Alert",
+        "alert_link": "https://security.microsoft.com/alerts/ALT-002",
+        "alert_date": "2026-07-01T09:00:00Z",
+    }
+    mock_sd.to_traces_data.return_value = mock_trace
+
+    return [mock_sd]
+
+
+def _given_empty_fetched_data() -> None:
+    """Given fetch_data() returns empty list.
+
+    Sets chunk8 state so _when_engine_processes_batch returns [] for data.
+    """
+    _CHUNK8_STATE["fetch_result"] = []
+
+
+def _given_fetched_data_error() -> None:
+    """Given fetch_data() raises an exception.
+
+    Sets chunk8 state so _when_engine_processes_batch raises on fetch.
+    """
+    _CHUNK8_STATE["fetch_error"] = RuntimeError("Connection timeout")
+
+
+def _when_engine_processes_batch(
+    expectations: list,
+    alert_data: list,
+) -> list:
+    """When the engine processes the batch.
+
+    Instantiates a minimal BasicCollectorEngine with mocked dependencies
+    and calls _process_batch with the provided expectations and alert data.
+
+    Args:
+        expectations: List of expectation objects to process.
+        alert_data: List of source data objects (mocked).
+
+    Returns:
+        List of ExpectationResult objects.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from pyoaev.helpers import OpenAEVDetectionHelper
+    from src.collector.engines.basic import BasicCollectorEngine
+    from src.collector.models.data import OAEVData
+    from src.collector.models.source import SourceHandler
+    from src.collector.protocols.data_fetcher import DataFetcherProtocol
+    from src.models.settings.source_configs import _ConfigLoaderSource
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    # Check for error scenario
+    if _CHUNK8_STATE.get("fetch_error"):
+        data = [
+            _CHUNK8_STATE["fetch_error"],
+        ]  # trigger error path
+    else:
+        data = alert_data if alert_data else _CHUNK8_STATE.get("fetch_result", [])
+
+    # Build signature groups for matching
+    sig_groups = SourceHandler.get_expectation_signature_groups(
+        SUPPORTED_SIGNATURES, expectations[0]
+    )
+
+    # Detection helper that matches based on sig groups
+    helper = OpenAEVDetectionHelper(
+        logger=MagicMock(),
+        relevant_signatures_types=SUPPORTED_SIGNATURES,
+    )
+
+    # Mock the source handler to inject our data
+    mock_handler = MagicMock(spec=SourceHandler)
+    mock_handler.config = _ConfigLoaderSource(
+        tenant_id="test-tenant-id",
+        client_id="test-client-id",
+        client_secret="test-secret",
+    )
+
+    def get_source_data(fetcher):
+        if _CHUNK8_STATE.get("fetch_error"):
+            raise _CHUNK8_STATE["fetch_error"]
+        return data
+
+    mock_handler.get_source_data = get_source_data
+    mock_handler.serialize_as_oaevdata = SourceHandler.serialize_as_oaevdata
+    mock_handler.get_expectation_signature_groups = (
+        SourceHandler.get_expectation_signature_groups
+    )
+    mock_handler.match_signature_groups_and_oaevdata = (
+        SourceHandler.match_signature_groups_and_oaevdata
+    )
+    mock_handler.serialize_as_tracedata = SourceHandler.serialize_as_tracedata
+    mock_handler.match_expectation_and_sourcedata = (
+        SourceHandler.match_expectation_and_sourcedata
+    )
+    mock_handler.build_fetch_params_hook = SourceHandler.build_fetch_params_hook
+
+    # Build engine with real Source instance
+    from src.collector.models.source import Source
+    from src.source.defender_o365_data_fetcher import DefenderO365DataFetcher
+    from src.source.source_data import MicrosoftDefenderO365SourceData
+
+    # Simple data fetcher class to avoid auth during test
+    class MockDataFetcher(DefenderO365DataFetcher):
+        def __init__(
+            self, config, fetch_params_hook=None
+        ):
+            self.config = config
+            self._fetch_params_hook = fetch_params_hook
+
+    mock_source = Source(
+        data_fetcher_model=MockDataFetcher,
+        source_data_model=MicrosoftDefenderO365SourceData,
+        signatures=SUPPORTED_SIGNATURES,
+    )
+
+    from pyoaev import OpenAEV
+
+    engine = BasicCollectorEngine(
+        name="Test Collector",
+        collector_id="test-collector-id",
+        source=mock_source,
+        source_handler=mock_handler,
+        oaev_api=MagicMock(spec=OpenAEV),
+    )
+    engine.configure_engine(MagicMock())
+
+    return engine._process_batch(expectations)
+
+
+def _when_source_handler_filters_sigs(expectation) -> dict:
+    """When SourceHandler.get_expectation_signature_groups filters signatures.
+
+    Args:
+        expectation: The expectation object to filter.
+
+    Returns:
+        The filtered signature groups dict.
+    """
+    from src.collector.models.source import SourceHandler
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    return SourceHandler.get_expectation_signature_groups(
+        SUPPORTED_SIGNATURES, expectation
+    )
+
+
+# --------
+# Then helpers
+# --------
+
+
+def _then_expectation_result_is_valid_with_traces(result) -> None:
+    """Then ExpectationResult.is_valid is True and matched_alerts contains traces.
+
+    Args:
+        result: The ExpectationResult to check.
+    """
+    assert result.is_valid is True, f"Expected is_valid=True, got {result.is_valid}"
+    assert (
+        len(result.matched_alerts) > 0
+    ), f"Expected matched_alerts to be non-empty, got {result.matched_alerts}"
+
+
+def _then_expectation_result_is_valid_without_traces(result) -> None:
+    """Then ExpectationResult.is_valid is True.
+
+    Args:
+        result: The ExpectationResult to check.
+    """
+    assert result.is_valid is True, f"Expected is_valid=True, got {result.is_valid}"
+
+
+def _then_expectation_result_not_valid_no_traces(result) -> None:
+    """Then ExpectationResult.is_valid is False and matched_alerts is empty.
+
+    Args:
+        result: The ExpectationResult to check.
+    """
+    assert result.is_valid is False, f"Expected is_valid=False, got {result.is_valid}"
+    assert (
+        len(result.matched_alerts) == 0
+    ), f"Expected matched_alerts to be empty, got {result.matched_alerts}"
+
+
+def _then_only_supported_sigs_retained(sig_groups: dict) -> None:
+    """Then only signatures matching SUPPORTED_SIGNATURES are retained.
+
+    Args:
+        sig_groups: The filtered signature groups dict.
+    """
+    from pyoaev.signatures.types import SignatureTypes
+    from src.source.signatures import SUPPORTED_SIGNATURES
+
+    supported_values = {sig.value for sig in SUPPORTED_SIGNATURES}
+    for sig_type_key in sig_groups:
+        assert (
+            sig_type_key in supported_values
+        ), f"Unexpected signature type '{sig_type_key}' in groups"
+
+
+def _then_all_results_invalid(results: list) -> None:
+    """Then all ExpectationResult objects have is_valid=False.
+
+    Args:
+        results: The list of ExpectationResult objects to check.
+    """
+    for result in results:
+        assert (
+            result.is_valid is False
+        ), f"Expected is_valid=False for {result.expectation_id}, got {result.is_valid}"
+
+
+def _then_expectation_result_has_error(result) -> None:
+    """Then ExpectationResult has is_valid=False and error_message set.
+
+    Args:
+        result: The ExpectationResult to check.
+    """
+    assert result.is_valid is False, f"Expected is_valid=False, got {result.is_valid}"
+    assert (
+        result.error_message is not None
+    ), f"Expected error_message to be set, got {result.error_message}"
+
+
+# --------
+# Internal helpers
+# --------
+
+
+def _sig_test_value_for_type(sig_type) -> str:
+    """Return a test-appropriate value for a signature type.
+
+    Args:
+        sig_type: A SignatureTypes enum value.
+
+    Returns:
+        A string value suitable for test expectations.
+    """
+    from pyoaev.signatures.types import SignatureTypes
+
+    VALUES = {
+        SignatureTypes.SIG_TYPE_SOURCE_EMAIL: "bad@evil.com",
+        SignatureTypes.SIG_TYPE_TARGET_EMAIL: "victim@corp.com",
+        SignatureTypes.SIG_TYPE_URL_HASH: "6e828dac1a6b547942ad393d0e3b5e37e50e974a86c8c61e5b77e6a0c7b7c6d",
+        SignatureTypes.SIG_TYPE_FILE_HASH: "abc123",
+        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER: "header-val",
+    }
+    return VALUES.get(sig_type, "test-value")

--- a/microsoft-defender-o365/tests/features/matching_integration.feature
+++ b/microsoft-defender-o365/tests/features/matching_integration.feature
@@ -1,0 +1,50 @@
+@matching @oaev @microsoft-defender-o365
+
+Feature: BasicCollectorEngine produces ExpectationResult for O365 alerts via template matching flow
+
+  As a collector integration
+  I want the template engine to match O365 OAEVData against expectations using the 5 supported signatures
+  So that satisfied expectations produce ExpectationResult with is_valid=True and matched traces
+
+  Background:
+    Given SUPPORTED_SIGNATURES is defined with 5 types
+    And BasicCollectorEngine is configured with DefenderO365DataFetcher and MicrosoftDefenderO365SourceData
+    And OpenAEVDetectionHelper is initialized with the 5 supported signature types
+
+  Scenario: Fully matching alert produces ExpectationResult with is_valid=True
+    Given a DetectionExpectation with signatures matching the 5 supported types
+    And MicrosoftDefenderO365SourceData.to_oaev_data() produces OAEVData with matching values for all signature keys
+    And MicrosoftDefenderO365SourceData.is_detected() returns True
+    When the engine processes the expectation against the fetched data
+    Then ExpectationResult.is_valid is True
+    And ExpectationResult.matched_alerts contains the serialized TraceData
+
+  Scenario: Non-matching alert produces ExpectationResult with is_valid=False
+    Given a DetectionExpectation with signatures for the supported types
+    And MicrosoftDefenderO365SourceData.to_oaev_data() produces OAEVData with non-matching values
+    When the engine processes the expectation against the fetched data
+    Then ExpectationResult.is_valid is False
+    And ExpectationResult.matched_alerts is empty
+
+  Scenario: Unsupported signature types in expectation are filtered out
+    Given an expectation with signatures including types NOT in SUPPORTED_SIGNATURES
+    When SourceHandler.get_expectation_signature_groups filters against the 5 supported types
+    Then only signatures matching SUPPORTED_SIGNATURES are retained in the groups
+    And unsupported types are silently ignored
+
+  Scenario: PreventionExpectation with is_prevented=True produces is_valid=True with break
+    Given a PreventionExpectation with matching signatures
+    And MicrosoftDefenderO365SourceData.is_prevented() returns True
+    When the engine processes the expectation
+    Then ExpectationResult.is_valid is True
+    And processing breaks out of the data loop (breakflag=True)
+
+  Scenario: Empty fetched data produces is_valid=False for all expectations
+    Given expectations exist but DefenderO365DataFetcher.fetch_data() returns empty list
+    When the engine processes the batch
+    Then all ExpectationResult objects have is_valid=False
+
+  Scenario: Data fetch error produces ExpectationResult.from_error per expectation
+    Given DefenderO365DataFetcher.fetch_data() raises an exception
+    When the engine processes the batch
+    Then each expectation gets an ExpectationResult with is_valid=False and error_message set

--- a/microsoft-defender-o365/tests/features/test_matching_integration.py
+++ b/microsoft-defender-o365/tests/features/test_matching_integration.py
@@ -3,7 +3,6 @@
 Uses raw pytest with _given/_when/_then helpers. No pytest-bdd.
 """
 
-import pytest
 from tests.conftest import (
     _given_detection_expectation_with_supported_sigs,
     _given_empty_fetched_data,
@@ -15,7 +14,6 @@ from tests.conftest import (
     _then_all_results_invalid,
     _then_expectation_result_has_error,
     _then_expectation_result_is_valid_with_traces,
-    _then_expectation_result_is_valid_without_traces,
     _then_expectation_result_not_valid_no_traces,
     _then_only_supported_sigs_retained,
     _when_engine_processes_batch,

--- a/microsoft-defender-o365/tests/features/test_matching_integration.py
+++ b/microsoft-defender-o365/tests/features/test_matching_integration.py
@@ -1,0 +1,123 @@
+"""Behavioural tests for the matching integration flow - Gherkin GWT Format.
+
+Uses raw pytest with _given/_when/_then helpers. No pytest-bdd.
+"""
+
+import pytest
+from tests.conftest import (
+    _given_detection_expectation_with_supported_sigs,
+    _given_empty_fetched_data,
+    _given_expectation_with_unsupported_sigs,
+    _given_fetched_data_error,
+    _given_matching_alert_data,
+    _given_non_matching_alert_data,
+    _given_prevention_expectation_with_supported_sigs,
+    _then_all_results_invalid,
+    _then_expectation_result_has_error,
+    _then_expectation_result_is_valid_with_traces,
+    _then_expectation_result_is_valid_without_traces,
+    _then_expectation_result_not_valid_no_traces,
+    _then_only_supported_sigs_retained,
+    _when_engine_processes_batch,
+    _when_source_handler_filters_sigs,
+)
+
+# --------
+# Scenarios
+# --------
+
+
+# Scenario: Fully matching alert produces ExpectationResult with is_valid=True
+def test_fully_matching_alert_produces_valid_result():
+    """Scenario: Fully matching alert produces ExpectationResult with is_valid=True."""
+    # Given: a DetectionExpectation with matching signatures
+    expectation = _given_detection_expectation_with_supported_sigs()
+
+    # Given: source data producing matching OAEVData and is_detected()=True
+    alert_data = _given_matching_alert_data()
+
+    # When: the engine processes the expectation against the fetched data
+    results = _when_engine_processes_batch([expectation], alert_data)
+
+    # Then: ExpectationResult.is_valid is True
+    _then_expectation_result_is_valid_with_traces(results[0])
+
+
+# Scenario: Non-matching alert produces ExpectationResult with is_valid=False
+def test_non_matching_alert_produces_invalid_result():
+    """Scenario: Non-matching alert produces ExpectationResult with is_valid=False."""
+    # Given: a DetectionExpectation with signatures for supported types
+    expectation = _given_detection_expectation_with_supported_sigs()
+
+    # Given: source data producing non-matching OAEVData
+    alert_data = _given_non_matching_alert_data()
+
+    # When: the engine processes the expectation against the fetched data
+    results = _when_engine_processes_batch([expectation], alert_data)
+
+    # Then: ExpectationResult.is_valid is False and matched_alerts is empty
+    _then_expectation_result_not_valid_no_traces(results[0])
+
+
+# Scenario: Unsupported signature types in expectation are filtered out
+def test_unsupported_signature_types_filtered():
+    """Scenario: Unsupported signature types in expectation are filtered out."""
+    # Given: an expectation with signatures including unsupported types
+    expectation = _given_expectation_with_unsupported_sigs()
+
+    # When: SourceHandler.get_expectation_signature_groups filters
+    sig_groups = _when_source_handler_filters_sigs(expectation)
+
+    # Then: only signatures matching SUPPORTED_SIGNATURES are retained
+    _then_only_supported_sigs_retained(sig_groups)
+
+
+# Scenario: PreventionExpectation with is_prevented=True produces is_valid=True with break
+def test_prevention_expectation_produces_valid_with_break():
+    """Scenario: PreventionExpectation with is_prevented=True produces is_valid=True with break."""
+    # Given: a PreventionExpectation with matching signatures
+    expectation = _given_prevention_expectation_with_supported_sigs()
+
+    # Given: source data with is_prevented()=True
+    alert_data = _given_matching_alert_data(prevention=True)
+
+    # When: the engine processes the expectation
+    results = _when_engine_processes_batch([expectation], alert_data)
+
+    # Then: ExpectationResult.is_valid is True
+    _then_expectation_result_is_valid_with_traces(results[0])
+
+
+# Scenario: Empty fetched data produces is_valid=False for all expectations
+def test_empty_fetched_data_produces_invalid():
+    """Scenario: Empty fetched data produces is_valid=False for all expectations."""
+    # Given: expectations exist
+    expectation1 = _given_detection_expectation_with_supported_sigs()
+    expectation2 = _given_detection_expectation_with_supported_sigs("exp-002")
+
+    # Given: fetch_data() returns empty list
+    _given_empty_fetched_data()
+
+    # When: the engine processes the batch
+    results = _when_engine_processes_batch([expectation1, expectation2], [])
+
+    # Then: all ExpectationResult objects have is_valid=False
+    _then_all_results_invalid(results)
+
+
+# Scenario: Data fetch error produces ExpectationResult.from_error per expectation
+def test_data_fetch_error_produces_error_result():
+    """Scenario: Data fetch error produces ExpectationResult.from_error per expectation."""
+    # Given: expectations exist
+    expectation1 = _given_detection_expectation_with_supported_sigs()
+    expectation2 = _given_detection_expectation_with_supported_sigs("exp-002")
+
+    # Given: fetch_data() raises an exception
+    _given_fetched_data_error()
+
+    # When: the engine processes the batch
+    results = _when_engine_processes_batch([expectation1, expectation2], [])
+
+    # Then: each expectation gets an ExpectationResult with is_valid=False and error_message
+    for result in results:
+        _then_expectation_result_has_error(result)


### PR DESCRIPTION
Parent Issue: #505
Parent PR (MVP): #492

## Contracts

### Input Contract

All inputs are template-internal, the engine receives them from the `Source` wiring:

```python
# From Source wiring (CHK.1 scaffold)
source = Source(
    data_fetcher_model=DefenderO365DataFetcher,      # CHK.6
    source_data_model=DefenderO365SourceData,         # CHK.7
    signatures=SUPPORTED_SIGNATURES,                   # CHK.5
)

# Expectations fetched from OpenAEV API at runtime
expectations: list[DetectionExpectation | PreventionExpectation]
```

### Output Contract

```python
# Template-provided — NOT defined by the collector
class ExpectationResult(BaseModel):
    expectation_id: str
    is_valid: bool
    expectation: Any | None = None
    matched_alerts: list[dict[str, Any]] = []
    error_message: str | None = None
    processing_time: float | None = None
```

Consumed by: CHK.9 (serializer) and the template's `ExpectationUploader` / `TraceUploader`.

## Acceptance Criteria

```gherkin
@matching @oaev @microsoft-defender-o365

Feature: BasicCollectorEngine produces ExpectationResult for O365 alerts via template matching flow
  As a collector integration
  I want the template engine to match O365 OAEVData against expectations using the 7 supported signatures
  So that satisfied expectations produce ExpectationResult with is_valid=True and matched traces

  Background:
    Given SUPPORTED_SIGNATURES is defined with 7 types
    And BasicCollectorEngine is configured with DefenderO365DataFetcher and DefenderO365SourceData
    And OpenAEVDetectionHelper is initialized with the 7 supported signature types

  Scenario: Fully matching alert produces ExpectationResult with is_valid=True
    Given a DetectionExpectation with signatures matching the 7 supported types
    And DefenderO365SourceData.to_oaev_data() produces OAEVData with matching values for all signature keys
    And DefenderO365SourceData.is_detected() returns True
    When the engine processes the expectation against the fetched data
    Then ExpectationResult.is_valid is True
    And ExpectationResult.matched_alerts contains the serialized TraceData

  Scenario: Non-matching alert produces ExpectationResult with is_valid=False
    Given a DetectionExpectation with signatures for the supported types
    And DefenderO365SourceData.to_oaev_data() produces OAEVData with non-matching values
    When the engine processes the expectation against the fetched data
    Then ExpectationResult.is_valid is False
    And ExpectationResult.matched_alerts is empty

  Scenario: Unsupported signature types in expectation are filtered out
    Given an expectation with signatures including types NOT in SUPPORTED_SIGNATURES
    When SourceHandler.get_expectation_signature_groups filters against the 7 supported types
    Then only signatures matching SUPPORTED_SIGNATURES are retained in the groups
    And unsupported types are silently ignored

  Scenario: PreventionExpectation with is_prevented=True produces is_valid=True with break
    Given a PreventionExpectation with matching signatures
    And DefenderO365SourceData.is_prevented() returns True
    When the engine processes the expectation
    Then ExpectationResult.is_valid is True
    And processing breaks out of the data loop (breakflag=True)

  Scenario: Empty fetched data produces is_valid=False for all expectations
    Given expectations exist but DefenderO365DataFetcher.fetch_data() returns empty list
    When the engine processes the batch
    Then all ExpectationResult objects have is_valid=False

  Scenario: Data fetch error produces ExpectationResult.from_error per expectation
    Given DefenderO365DataFetcher.fetch_data() raises an exception
    When the engine processes the batch
    Then each expectation gets an ExpectationResult with is_valid=False and error_message set
```

## Done Checklist

- [ ]  Confirm default `SourceHandler` is sufficient for O365 (no custom subclass needed)
- [ ]  Write integration tests: engine loop with O365 SourceData, DataFetcher, and SUPPORTED_SIGNATURES
- [ ]  Test: matching expectation with fully populated OAEVData produces `is_valid=True`
- [ ]  Test: non-matching expectation produces `is_valid=False` with empty `matched_alerts`
- [ ]  Test: `SUPPORTED_SIGNATURES` correctly filters unsupported signature types from expectations
- [ ]  Test: `is_prevented()` True on PreventionExpectation → `is_valid=True` with break
- [ ]  Test: `is_detected()` True on DetectionExpectation → `is_valid=True`
- [ ]  Test: engine handles empty data (no alerts) gracefully
- [ ]  Test: engine handles data fetch error → `ExpectationResult.from_error()` per expectation
- [ ]  Create a dedicated PR linked to the Umbrella issue

Closes #505
