### PR TITLE
chore(collectors): align manifest metadata with the platform catalog (#514)

### DIFF
--- a/atomic-red-team/manifest-metadata.json
+++ b/atomic-red-team/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Atomic Red Team",
   "slug": "openaev_atomic_red_team",
-  "description": "Collect Atomic Red Team payload library",
-  "short_description": "Collect Atomic Red Team payload library",
+  "description": "Import the Atomic Red Team library of MITRE ATT&CK-aligned tests into OpenAEV as ready-to-run payloads, so you can exercise detection and prevention against community adversary techniques.",
+  "short_description": "Import the Atomic Red Team payload library",
   "use_cases": ["Payload collection"],
   "verified": true,
   "last_verified_date": "",

--- a/aws-resources/manifest-metadata.json
+++ b/aws-resources/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Amazon Web Service Resources",
   "slug": "openaev_aws_resources",
-  "description": "Allow registration of agentless endpoints coming from Amazon Web Service",
-  "short_description": "Allow registration of agentless endpoints coming from Amazon Web Service",
+  "description": "Register agentless endpoints from Amazon Web Services EC2 instances in OpenAEV, so cloud resources can be targeted by simulations without deploying an agent.",
+  "short_description": "Register AWS EC2 instances as agentless endpoints",
   "use_cases": ["Endpoint collection"],
   "verified": true,
   "last_verified_date": "",

--- a/aws-resources/manifest-metadata.json
+++ b/aws-resources/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_aws_resources",
   "description": "Register agentless endpoints from Amazon Web Services EC2 instances in OpenAEV, so cloud resources can be targeted by simulations without deploying an agent.",
   "short_description": "Register AWS EC2 instances as agentless endpoints",
-  "use_cases": ["Endpoint collection"],
+  "use_cases": ["Asset collection", "Cloud security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/cisco-ai-defense/manifest-metadata.json
+++ b/cisco-ai-defense/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_cisco_ai_defense",
   "description": "Validate that Cisco AI Defense (Robust Intelligence) detects or blocks AI adversarial injects by replaying the attack content through the Cisco AI Defense inspection API.",
   "short_description": "Validate Cisco AI Defense detection and prevention",
-  "use_cases": ["Security response"],
+  "use_cases": ["Security response", "AI security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/crowdstrike/manifest-metadata.json
+++ b/crowdstrike/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
-  "title": "Crowdstrike",
+  "title": "CrowdStrike",
   "slug": "openaev_crowdstrike",
-  "description": "Collect responses from Crowdstrike EDR",
-  "short_description": "Collect responses from Crowdstrike EDR",
+  "description": "Validate OpenAEV detection and prevention expectations against CrowdStrike Falcon by collecting the detections and alerts its endpoint protection raises in response to simulated attacks.",
+  "short_description": "Collect detections from CrowdStrike Falcon EDR",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/elastic/manifest-metadata.json
+++ b/elastic/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Elastic Security",
   "slug": "openaev_elastic",
-  "description": "Collect responses from Elastic Security",
-  "short_description": "Collect responses from Elastic Security",
+  "description": "Validate OpenAEV detection expectations against Elastic Security by collecting the alerts its SIEM and endpoint protection raise in response to simulated attacks.",
+  "short_description": "Collect detections from Elastic Security",
   "use_cases": ["Security response"],
   "verified": false,
   "last_verified_date": "",

--- a/google-workspace/manifest-metadata.json
+++ b/google-workspace/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
-  "title": "Google workspace",
+  "title": "Google Workspace",
   "slug": "openaev_google_workspace",
-  "description": "Collect users information from Google Workspace to create players",
-  "short_description": "Collect users information from Google Workspace to create players",
+  "description": "Synchronize users and groups from Google Workspace into OpenAEV as players and teams, so simulations can target your real organizational directory.",
+  "short_description": "Import users from Google Workspace as players",
   "use_cases": ["Player collection"],
   "verified": true,
   "last_verified_date": "",

--- a/hiddenlayer/manifest-metadata.json
+++ b/hiddenlayer/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_hiddenlayer",
   "description": "Validate that HiddenLayer AI Runtime Security (AIDR) detects or blocks AI adversarial injects by replaying the attack content through the HiddenLayer Interactions endpoint.",
   "short_description": "Validate HiddenLayer AIDR detection and prevention",
-  "use_cases": ["Security response"],
+  "use_cases": ["Security response", "AI security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/lakera-guard/manifest-metadata.json
+++ b/lakera-guard/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_lakera_guard",
   "description": "Validate that Lakera Guard (Check Point AI Security) detects or prevents AI adversarial injects by replaying the attack content through the Lakera screening API.",
   "short_description": "Validate Lakera Guard detection and prevention",
-  "use_cases": ["Security response"],
+  "use_cases": ["Security response", "AI security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/logrhythm/manifest-metadata.json
+++ b/logrhythm/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "LogRhythm",
   "slug": "openaev_logrhythm",
-  "description": "Collect responses from LogRhythm",
-  "short_description": "Collect responses from LogRhythm",
+  "description": "Validate OpenAEV detection expectations against LogRhythm by collecting the alarms your SIEM raises in response to simulated attacks.",
+  "short_description": "Collect alarms from LogRhythm SIEM",
   "use_cases": ["Security response"],
   "verified": false,
   "last_verified_date": "",

--- a/microsoft-azure/manifest-metadata.json
+++ b/microsoft-azure/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_microsoft_azure",
   "description": "Register agentless endpoints from Microsoft Azure virtual machines in OpenAEV, so cloud instances can be targeted by simulations without deploying an agent.",
   "short_description": "Register Microsoft Azure virtual machines as agentless endpoints",
-  "use_cases": ["Asset collection"],
+  "use_cases": ["Asset collection", "Cloud security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/microsoft-azure/manifest-metadata.json
+++ b/microsoft-azure/manifest-metadata.json
@@ -1,9 +1,9 @@
 {
-  "title": "Microsoft azure",
+  "title": "Microsoft Azure",
   "slug": "openaev_microsoft_azure",
-  "description": "Allow registration of agentless endpoints coming from Microsoft Azure",
-  "short_description": "Allow registration of agentless endpoints coming from Microsoft Azure",
-  "use_cases": [],
+  "description": "Register agentless endpoints from Microsoft Azure virtual machines in OpenAEV, so cloud instances can be targeted by simulations without deploying an agent.",
+  "short_description": "Register Microsoft Azure virtual machines as agentless endpoints",
+  "use_cases": ["Asset collection"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/microsoft-defender/manifest-metadata.json
+++ b/microsoft-defender/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Microsoft Defender",
   "slug": "openaev_microsoft_defender",
-  "description": "Collect responses from Microsoft Defender",
-  "short_description": "Collect responses from Microsoft Defender",
+  "description": "Validate OpenAEV detection and prevention expectations against Microsoft Defender for Endpoint by collecting the alerts it raises in response to simulated attacks.",
+  "short_description": "Collect detections from Microsoft Defender for Endpoint",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/microsoft-entra/manifest-metadata.json
+++ b/microsoft-entra/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Microsoft Entra",
   "slug": "openaev_microsoft_entra",
-  "description": "Collect users information from Microsoft Entra to create players",
-  "short_description": "Collect users information from Microsoft Entra to create players",
+  "description": "Synchronize users and groups from Microsoft Entra ID (Azure AD) into OpenAEV as players and teams, so simulations can target your real organizational directory.",
+  "short_description": "Import users from Microsoft Entra ID as players",
   "use_cases": ["Player collection"],
   "verified": true,
   "last_verified_date": "",

--- a/microsoft-intune/manifest-metadata.json
+++ b/microsoft-intune/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_microsoft_intune",
   "description": "Register agentless endpoints managed by Microsoft Intune in OpenAEV, so managed devices can be targeted by simulations without deploying an agent.",
   "short_description": "Register Microsoft Intune managed devices as agentless endpoints",
-  "use_cases": ["Endpoint collection"],
+  "use_cases": ["Asset collection"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/microsoft-intune/manifest-metadata.json
+++ b/microsoft-intune/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Microsoft Intune",
   "slug": "openaev_microsoft_intune",
-  "description": "Allow registration of agentless endpoints coming from Microsoft Intune endpoints",
-  "short_description": "Allow registration of agentless endpoints coming from Microsoft Intune endpoints",
+  "description": "Register agentless endpoints managed by Microsoft Intune in OpenAEV, so managed devices can be targeted by simulations without deploying an agent.",
+  "short_description": "Register Microsoft Intune managed devices as agentless endpoints",
   "use_cases": ["Endpoint collection"],
   "verified": true,
   "last_verified_date": "",

--- a/microsoft-sentinel/manifest-metadata.json
+++ b/microsoft-sentinel/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Microsoft Sentinel",
   "slug": "openaev_microsoft_sentinel",
-  "description": "Collect responses from Microsoft Sentinel",
-  "short_description": "Collect responses from Microsoft Sentinel",
+  "description": "Validate OpenAEV detection expectations against Microsoft Sentinel by collecting the incidents and alerts your cloud-native SIEM correlates in response to simulated attacks.",
+  "short_description": "Collect incidents and alerts from Microsoft Sentinel",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/mitre-atlas/manifest-metadata.json
+++ b/mitre-atlas/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_mitre_atlas",
   "description": "Collect MITRE ATLAS (Adversarial Threat Landscape for AI Systems) tactics and techniques library",
   "short_description": "Collect MITRE ATLAS AI adversarial tactics and techniques",
-  "use_cases": ["Data collection"],
+  "use_cases": ["Data collection", "AI security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/mitre-attack/manifest-metadata.json
+++ b/mitre-attack/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "MITRE Att&ck",
   "slug": "openaev_mitre_attack",
-  "description": "Collect MITRE Att&ck tactics and techniques library",
-  "short_description": "Collect MITRE Att&ck tactics and techniques library",
+  "description": "Import the MITRE ATT&CK knowledge base of adversary tactics and techniques into OpenAEV, so injects and payloads can be mapped to the ATT&CK matrix.",
+  "short_description": "Import the MITRE ATT&CK tactics and techniques",
   "use_cases": ["Data collection"],
   "verified": true,
   "last_verified_date": "",

--- a/netwitness/manifest-metadata.json
+++ b/netwitness/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "NetWitness",
   "slug": "openaev_netwitness",
-  "description": "Collect responses from NetWitness",
-  "short_description": "Collect responses from NetWitness",
+  "description": "Validate OpenAEV detection expectations against NetWitness by collecting the alerts its network detection and response platform raises in response to simulated attacks.",
+  "short_description": "Collect detections from NetWitness",
   "use_cases": ["Security response"],
   "verified": false,
   "last_verified_date": "",

--- a/nvd-nist-cve/manifest-metadata.json
+++ b/nvd-nist-cve/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "NVD NIST",
   "slug": "openaev_nvd_nist_cve",
-  "description": "Collect NVD NIST database",
-  "short_description": "Collect NVD NIST database",
+  "description": "Import CVE vulnerability data from the National Vulnerability Database (NVD) maintained by NIST, enriching OpenAEV with authoritative vulnerability references.",
+  "short_description": "Import CVE vulnerabilities from the NIST NVD",
   "use_cases": ["Data collection"],
   "verified": true,
   "last_verified_date": "",

--- a/openaev/manifest-metadata.json
+++ b/openaev/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "OpenAEV Library",
   "slug": "openaev_openaev",
-  "description": "Collect OAEV payload library",
-  "short_description": "Collect OAEV payload library",
+  "description": "Import the curated OpenAEV payload library, giving you a maintained catalog of attack payloads to run in atomic tests and scenarios.",
+  "short_description": "Import the OpenAEV payload library",
   "use_cases": ["Payload collection"],
   "verified": true,
   "last_verified_date": "",

--- a/palo-alto-cortex-xdr/manifest-metadata.json
+++ b/palo-alto-cortex-xdr/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Palo Alto Cortex XDR",
   "slug": "palo_alto_cortex_xdr",
-  "description": "Collect alerts information from Palo Alto Cortex XDR",
-  "short_description": "Collect alerts information from Palo Alto Cortex XDR",
+  "description": "Validate OpenAEV detection and prevention expectations against Palo Alto Cortex XDR by collecting the alerts it raises in response to simulated attacks.",
+  "short_description": "Collect alerts from Palo Alto Cortex XDR",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/palo-alto-cortex-xsoar/manifest-metadata.json
+++ b/palo-alto-cortex-xsoar/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Palo Alto Cortex XSOAR",
   "slug": "palo_alto_cortex_xsoar",
-  "description": "Collect alerts information from Palo Alto Cortex XSOAR",
-  "short_description": "Collect alerts information from Palo Alto Cortex XSOAR",
+  "description": "Collect incidents from Palo Alto Cortex XSOAR to validate how your SOAR playbooks respond to OpenAEV simulated attacks.",
+  "short_description": "Collect incidents from Palo Alto Cortex XSOAR",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/prisma-airs/manifest-metadata.json
+++ b/prisma-airs/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_prisma_airs",
   "description": "Validate that Palo Alto Prisma AIRS (AI Runtime Security) detects or blocks AI adversarial injects by replaying the attack content through the Prisma AIRS Scan API.",
   "short_description": "Validate Prisma AIRS detection and prevention",
-  "use_cases": ["Security response"],
+  "use_cases": ["Security response", "AI security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/prompt-security/manifest-metadata.json
+++ b/prompt-security/manifest-metadata.json
@@ -3,7 +3,7 @@
   "slug": "openaev_prompt_security",
   "description": "Validate that Prompt Security (SentinelOne) detects or blocks AI adversarial injects by replaying the attack content through the Prompt Security protect API.",
   "short_description": "Validate Prompt Security detection and prevention",
-  "use_cases": ["Security response"],
+  "use_cases": ["Security response", "AI security"],
   "verified": true,
   "last_verified_date": "",
   "playbook_supported": false,

--- a/qradar/manifest-metadata.json
+++ b/qradar/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "IBM QRadar",
   "slug": "openaev_qradar",
-  "description": "Collect responses from IBM QRadar",
-  "short_description": "Collect responses from IBM QRadar",
+  "description": "Validate OpenAEV detection expectations against IBM QRadar by collecting the offenses your SIEM raises in response to simulated attacks.",
+  "short_description": "Collect offenses from IBM QRadar SIEM",
   "use_cases": ["Security response"],
   "verified": false,
   "last_verified_date": "",

--- a/sentinelone/manifest-metadata.json
+++ b/sentinelone/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "SentinelOne",
   "slug": "openaev_sentinelone",
-  "description": "Collect responses from SentinelOne",
-  "short_description": "Collect responses from SentinelOne",
+  "description": "Validate OpenAEV detection and prevention expectations against SentinelOne Singularity by collecting the threats and alerts its EDR raises in response to simulated attacks.",
+  "short_description": "Collect detections from SentinelOne EDR",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/splunk-es/manifest-metadata.json
+++ b/splunk-es/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Splunk Enterprise Security",
   "slug": "openaev_splunk_es",
-  "description": "Collect responses from Splunk Enterprise Security",
-  "short_description": "Collect responses from Splunk Enterprise Security",
+  "description": "Validate OpenAEV detection expectations against Splunk Enterprise Security by collecting the notable events your SIEM raises in response to simulated attacks.",
+  "short_description": "Collect notable events from Splunk Enterprise Security",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",

--- a/tanium-threat-response/manifest-metadata.json
+++ b/tanium-threat-response/manifest-metadata.json
@@ -1,8 +1,8 @@
 {
   "title": "Tanium Threat Response",
   "slug": "openaev_tanium_threat_response",
-  "description": "Collect responses from Tanium Threat Response",
-  "short_description": "Collect responses from Tanium Threat Response",
+  "description": "Validate OpenAEV detection and prevention expectations against Tanium Threat Response by collecting the alerts it raises in response to simulated attacks.",
+  "short_description": "Collect detections from Tanium Threat Response",
   "use_cases": ["Security response"],
   "verified": true,
   "last_verified_date": "",


### PR DESCRIPTION
## Related issue

Closes #514

## Summary

Align manifest-metadata.json of the collectors with the platform integrations catalog reworked in OpenAEV-Platform/openaev#6784 (catalog-integrators.json), which is the source of truth for marketplace metadata.

- Titles, descriptions and short descriptions of 21 collectors now match the catalog: proper product casing (e.g. 'CrowdStrike', 'Google Workspace', 'Microsoft Azure') and detailed marketplace descriptions instead of the generic 'Collect responses...' wording.
- use_cases now match the catalog for every collector present in it: aws-resources (Asset collection, Cloud security), microsoft-azure (adds Cloud security), microsoft-intune (Asset collection), and the six AI-defense collectors cisco-ai-defense, hiddenlayer, lakera-guard, mitre-atlas, prisma-airs and prompt-security (add AI security).

After this PR, every manifest field mirrored from the catalog (title, description, short_description, use_cases) is identical to catalog-integrators.json for all collectors in the catalog (the template collector is intentionally absent from it). Titles that could arguably be rebranded ('MITRE Att&ck', 'Amazon Web Service Resources') deliberately keep the catalog's exact wording; any rebranding should happen platform-side first and be mirrored here in a follow-up.

Payload authorship ('created by Atomic Red Team' filtering) is handled entirely platform-side by attributing upserted payloads to an organization named after the collector - no collector source change is needed.

## Test plan

- Scripted comparison of every manifest-metadata.json against catalog-integrators.json: zero mismatches on title, description, short_description and use_cases
- All JSON files remain valid (parsed by the comparison script)
- CI green (Tests Collectors matrix, CircleCI linter/formatting/test/build, codecov)
