### PR TITLE
feat(atomic-red-team): declare expected security platform types on imported payload expectations (#516)

### DIFF
--- a/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
+++ b/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
@@ -360,6 +360,13 @@ class OpenAEVAtomicRedTeam(CollectorDaemon):
                             "payload_attack_patterns": [attack_pattern],
                             "payload_arguments": arguments,
                             "payload_expectations": ["PREVENTION", "DETECTION"],
+                            # Atomic tests are endpoint command execution: the detecting/preventing
+                            # security platforms are endpoint agents (EDR/XDR) and the SIEM that
+                            # ingests their telemetry. Empty would mean "any platform".
+                            "payload_expected_security_platforms": {
+                                "DETECTION": ["EDR", "XDR", "SIEM"],
+                                "PREVENTION": ["EDR", "XDR"],
+                            },
                             "command_executor": EXECUTORS[
                                 atomic_test["executor"]["name"]
                             ],


### PR DESCRIPTION
## Proposed changes

Collectors side of the new optional expected-security-platform-types feature (pyoaev + openaev-app).

The backend now accepts a `payload_expected_security_platforms` map on payloads (`{expectation_type: [platform_type, ...]}`), which is applied to the payload's predefined technical expectations.

- `atomic-red-team`: Atomic Red Team tests are endpoint command execution, so their imported detection/prevention expectations are fulfilled by endpoint agents (EDR/XDR) and the SIEM ingesting their telemetry. Declares:
  - `DETECTION`: `EDR`, `XDR`, `SIEM`
  - `PREVENTION`: `EDR`, `XDR`

Collectors intentionally left unchanged:
- `mitre-attack` / `mitre-atlas`: import attack patterns only; they do not create payloads with expectations.
- `openaev`: mirrors payloads from the OpenAEV payloads repo as-is; expected types belong in that source repo JSON, not the collector code.

Empty / unset stays the default (any platform), so nothing changes until a type is declared.

## Related issues

Closes #516

## Checklist

- [x] I have made corresponding changes to the documentation (n/a - payload metadata only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (metadata pass-through; covered by backend payload tests)
