### PR TITLE
feat(openaev): declare default expected security platform types on native payload expectations (#518)

### DIFF
--- a/openaev/README.md
+++ b/openaev/README.md
@@ -133,6 +133,11 @@ On each run, the collector:
 4. Upserts the payload (tagged `source:openaev-datasets`, plus `type:native` when applicable), then deprecates the
    payloads previously imported by this collector that are no longer present in the manifest.
 
+When a payload entry does not declare `payload_expected_security_platforms` itself, the collector fills in a default
+for the expectation types the payload declares: `DETECTION` -> `EDR`, `XDR`, `SIEM` and `PREVENTION` -> `EDR`, `XDR`
+(native OpenAEV payloads are endpoint command execution / file drops). A value declared in the payload library JSON
+always takes precedence, and payloads without expectations are left untouched.
+
 ## Data source
 
 This collector reads a public data source, so no credentials or API key are required.

--- a/openaev/openaev/openaev_openaev.py
+++ b/openaev/openaev/openaev_openaev.py
@@ -20,6 +20,28 @@ DEFAULT_EXPECTED_SECURITY_PLATFORMS = {
 }
 
 
+def apply_default_expected_security_platforms(payload_information) -> None:
+    """Fill in default expected security platform types on the payload.
+
+    Only applies when the source repo JSON does not declare
+    payload_expected_security_platforms itself: an explicit value always wins,
+    including an explicit empty map (which means "any platform"). Defaults are
+    only declared for the expectation types the payload has; payloads without
+    expectations are left untouched.
+    """
+    if payload_information.get("payload_expected_security_platforms") is not None:
+        return
+    expected_security_platforms = {
+        expectation_type: list(platform_types)
+        for expectation_type, platform_types in DEFAULT_EXPECTED_SECURITY_PLATFORMS.items()
+        if expectation_type in (payload_information.get("payload_expectations") or [])
+    }
+    if expected_security_platforms:
+        payload_information["payload_expected_security_platforms"] = (
+            expected_security_platforms
+        )
+
+
 class OpenAEVOpenAEV(CollectorDaemon):
     def __init__(
         self,
@@ -149,17 +171,7 @@ class OpenAEVOpenAEV(CollectorDaemon):
             # Declare expected security platform types on the payload's
             # predefined expectations when the source repo JSON does not
             # declare them itself (only for expectation types the payload has).
-            if not payload_information.get("payload_expected_security_platforms"):
-                expected_security_platforms = {
-                    expectation_type: platform_types
-                    for expectation_type, platform_types in DEFAULT_EXPECTED_SECURITY_PLATFORMS.items()
-                    if expectation_type
-                    in (payload_information.get("payload_expectations") or [])
-                }
-                if expected_security_platforms:
-                    payload_information["payload_expected_security_platforms"] = (
-                        expected_security_platforms
-                    )
+            apply_default_expected_security_platforms(payload_information)
 
             self.api.payload.upsert(payload_information)
             payload_external_ids.append(payload_information["payload_external_id"])

--- a/openaev/openaev/openaev_openaev.py
+++ b/openaev/openaev/openaev_openaev.py
@@ -8,6 +8,17 @@ from pyoaev.daemons import CollectorDaemon
 
 from openaev.configuration.config_loader import ConfigLoader
 
+# OpenAEV native payloads are endpoint command execution / file drops: the
+# detecting/preventing security platforms are endpoint agents (EDR/XDR) and the
+# SIEM that ingests their telemetry. Applied per expectation type declared on
+# the payload, only when the source repo JSON does not declare
+# payload_expected_security_platforms itself (an explicit value always wins).
+# Empty would mean "any platform".
+DEFAULT_EXPECTED_SECURITY_PLATFORMS = {
+    "DETECTION": ["EDR", "XDR", "SIEM"],
+    "PREVENTION": ["EDR", "XDR"],
+}
+
 
 class OpenAEVOpenAEV(CollectorDaemon):
     def __init__(
@@ -134,6 +145,21 @@ class OpenAEVOpenAEV(CollectorDaemon):
                 payload_information["executable_file"] = new_document["document_id"]
             elif "file_drop_file" in payload_information and new_document is not None:
                 payload_information["file_drop_file"] = new_document["document_id"]
+
+            # Declare expected security platform types on the payload's
+            # predefined expectations when the source repo JSON does not
+            # declare them itself (only for expectation types the payload has).
+            if not payload_information.get("payload_expected_security_platforms"):
+                expected_security_platforms = {
+                    expectation_type: platform_types
+                    for expectation_type, platform_types in DEFAULT_EXPECTED_SECURITY_PLATFORMS.items()
+                    if expectation_type
+                    in (payload_information.get("payload_expectations") or [])
+                }
+                if expected_security_platforms:
+                    payload_information["payload_expected_security_platforms"] = (
+                        expected_security_platforms
+                    )
 
             self.api.payload.upsert(payload_information)
             payload_external_ids.append(payload_information["payload_external_id"])

--- a/openaev/pyproject.toml
+++ b/openaev/pyproject.toml
@@ -32,6 +32,14 @@ dev = [
     "pyoaev",
 ]
 
+[tool.poetry.group.test.dependencies]
+pytest = "^9.0.2"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+
 [tool.cmw]
 install-command = "poetry install --extras prod"
 config-dump-command = "poetry run python -m openaev.openaev_openaev --dump-config-schema"

--- a/openaev/tests/test_default_expected_security_platforms.py
+++ b/openaev/tests/test_default_expected_security_platforms.py
@@ -59,6 +59,21 @@ def test_explicit_empty_map_is_preserved():
     assert payload_information["payload_expected_security_platforms"] == {}
 
 
+def test_explicit_null_is_treated_as_missing():
+    # A JSON null (Python None) means "not declared" and gets the defaults.
+    payload_information = {
+        "payload_expectations": ["PREVENTION", "DETECTION"],
+        "payload_expected_security_platforms": None,
+    }
+
+    apply_default_expected_security_platforms(payload_information)
+
+    assert payload_information["payload_expected_security_platforms"] == {
+        "DETECTION": ["EDR", "XDR", "SIEM"],
+        "PREVENTION": ["EDR", "XDR"],
+    }
+
+
 def test_payload_without_expectations_left_untouched():
     for payload_information in ({}, {"payload_expectations": []}):
         apply_default_expected_security_platforms(payload_information)

--- a/openaev/tests/test_default_expected_security_platforms.py
+++ b/openaev/tests/test_default_expected_security_platforms.py
@@ -1,0 +1,83 @@
+from openaev.openaev_openaev import (
+    DEFAULT_EXPECTED_SECURITY_PLATFORMS,
+    apply_default_expected_security_platforms,
+)
+
+
+def test_fills_defaults_for_declared_expectation_types():
+    payload_information = {"payload_expectations": ["PREVENTION", "DETECTION"]}
+
+    apply_default_expected_security_platforms(payload_information)
+
+    assert payload_information["payload_expected_security_platforms"] == {
+        "DETECTION": ["EDR", "XDR", "SIEM"],
+        "PREVENTION": ["EDR", "XDR"],
+    }
+
+
+def test_fills_defaults_only_for_declared_expectation_types():
+    payload_information = {"payload_expectations": ["DETECTION"]}
+
+    apply_default_expected_security_platforms(payload_information)
+
+    assert payload_information["payload_expected_security_platforms"] == {
+        "DETECTION": ["EDR", "XDR", "SIEM"],
+    }
+
+
+def test_ignores_expectation_types_without_defaults():
+    payload_information = {"payload_expectations": ["MANUAL"]}
+
+    apply_default_expected_security_platforms(payload_information)
+
+    assert "payload_expected_security_platforms" not in payload_information
+
+
+def test_explicit_value_takes_precedence():
+    explicit = {"DETECTION": ["SIEM"]}
+    payload_information = {
+        "payload_expectations": ["PREVENTION", "DETECTION"],
+        "payload_expected_security_platforms": explicit,
+    }
+
+    apply_default_expected_security_platforms(payload_information)
+
+    assert payload_information["payload_expected_security_platforms"] == {
+        "DETECTION": ["SIEM"],
+    }
+
+
+def test_explicit_empty_map_is_preserved():
+    # An explicit empty map means "any platform" and must not be overwritten.
+    payload_information = {
+        "payload_expectations": ["PREVENTION", "DETECTION"],
+        "payload_expected_security_platforms": {},
+    }
+
+    apply_default_expected_security_platforms(payload_information)
+
+    assert payload_information["payload_expected_security_platforms"] == {}
+
+
+def test_payload_without_expectations_left_untouched():
+    for payload_information in ({}, {"payload_expectations": []}):
+        apply_default_expected_security_platforms(payload_information)
+
+        assert "payload_expected_security_platforms" not in payload_information
+
+
+def test_defaults_are_copied_per_payload():
+    first = {"payload_expectations": ["DETECTION"]}
+    second = {"payload_expectations": ["DETECTION"]}
+
+    apply_default_expected_security_platforms(first)
+    apply_default_expected_security_platforms(second)
+
+    first["payload_expected_security_platforms"]["DETECTION"].append("NDR")
+
+    assert second["payload_expected_security_platforms"]["DETECTION"] == [
+        "EDR",
+        "XDR",
+        "SIEM",
+    ]
+    assert DEFAULT_EXPECTED_SECURITY_PLATFORMS["DETECTION"] == ["EDR", "XDR", "SIEM"]


### PR DESCRIPTION
## Proposed changes

Follow-up to #517: the openaev collector (OpenAEV Datasets) was left out of the expected-security-platform-types rollout, but the payload library manifest does not declare `payload_expected_security_platforms` today, so native OpenAEV payloads still fall back to "any platform".

Native OpenAEV payloads are endpoint command execution / file drops, exactly like Atomic Red Team tests, so this PR applies the same defaults in the collector:

- When a manifest entry does not declare `payload_expected_security_platforms` itself (missing or null), fill in `DETECTION -> [EDR, XDR, SIEM]` and `PREVENTION -> [EDR, XDR]` for the expectation types the payload declares.
- A value declared in the payload library JSON always takes precedence (pass-through, never overridden), including an explicitly-declared empty map, which keeps meaning "any platform". Expected types can therefore still be moved to the source repo later without touching the collector.
- Payloads without expectations are left untouched (unset stays "any platform").

The default-filling logic lives in `apply_default_expected_security_platforms()` and is covered by unit tests in the new `openaev/tests/` directory. The GitHub Actions "Tests Collectors" workflow auto-discovers collectors with a `tests/` directory (`.github/scripts/build_test_matrix.py` + `run_test.sh`), so a dedicated "Test openaev" job now runs on every PR (green on this one, with codecov coverage upload). Covered cases: defaults per declared expectation type, explicit-value pass-through, explicit-empty-map preservation, explicit-null treated as missing, unknown expectation types, payloads without expectations, and per-payload copies of the default lists.

Verified against the current published manifest: the 17 payloads with DETECTION/PREVENTION expectations get the default map, and the 2 payloads without expectations stay unset.

Also documents the behavior in the collector README.

## Related issues

Closes #518

## Checklist

- [x] I have made corresponding changes to the documentation (README behavior note)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (unit tests for the default-filling / pass-through logic in `openaev/tests/`, run by the "Test openaev" CI job)
