### PR TITLE
fix(atomic-red-team): added external payload to ignored payload list to avoid VM instability  (#525)

### DIFF
--- a/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
+++ b/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
@@ -27,7 +27,8 @@ IGNORED_PAYLOADS = [
     "6aa58451-1121-4490-a8e9-1dada3f1c68c",
     "b854eb97-bf9b-45ab-a1b5-b94e4880c56b",
     "4ff64f0b-aaf2-4866-b39d-38d9791407cc",
-    "f3aa95fe-4f10-4485-ad26-abf22a764c52", #Ignore this payload because it is a Delete Filesystem - Linux from Atomic Red Team and it is not suitable for OpenAEV. It causes data loss and system instability.
+    "f3aa95fe-4f10-4485-ad26-abf22a764c52",  # Ignore this payload because it is a Delete Filesystem -
+    # Linux from Atomic Red Team and it is not suitable for OpenAEV. It causes data loss and system instability.
 ]
 
 PLATFORMS = {

--- a/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
+++ b/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
@@ -27,6 +27,7 @@ IGNORED_PAYLOADS = [
     "6aa58451-1121-4490-a8e9-1dada3f1c68c",
     "b854eb97-bf9b-45ab-a1b5-b94e4880c56b",
     "4ff64f0b-aaf2-4866-b39d-38d9791407cc",
+    "f3aa95fe-4f10-4485-ad26-abf22a764c52", #Ignore this payload because it is a Delete Filesystem - Linux from Atomic Red Team and it is not suitable for OpenAEV. It causes data loss and system instability.
 ]
 
 PLATFORMS = {

--- a/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
+++ b/atomic-red-team/atomic_red_team/openaev_atomic_red_team.py
@@ -27,8 +27,11 @@ IGNORED_PAYLOADS = [
     "6aa58451-1121-4490-a8e9-1dada3f1c68c",
     "b854eb97-bf9b-45ab-a1b5-b94e4880c56b",
     "4ff64f0b-aaf2-4866-b39d-38d9791407cc",
-    "f3aa95fe-4f10-4485-ad26-abf22a764c52",  # Ignore this payload because it is a Delete Filesystem -
-    # Linux from Atomic Red Team and it is not suitable for OpenAEV. It causes data loss and system instability.
+]
+
+# Ignore payloads that are deemed too harmful for the current OAEV capabilities
+FORBIDDEN_PAYLOADS = [
+    "f3aa95fe-4f10-4485-ad26-abf22a764c52",  # Delete Filesystem - Linux from Atomic Red Team (rational: data loss and system instability)
 ]
 
 PLATFORMS = {
@@ -239,6 +242,8 @@ class OpenAEVAtomicRedTeam(CollectorDaemon):
                     "atomic_tests"
                 ]:
                     if atomic_test["auto_generated_guid"] in IGNORED_PAYLOADS:
+                        continue
+                    if atomic_test["auto_generated_guid"] in FORBIDDEN_PAYLOADS:
                         continue
                     arguments = []
                     if (


### PR DESCRIPTION
### Proposed changes

* Creating a new list of payloads to skip named `FORBIDDEN_PAYLOADS` for payloads that are deemed too harmful for the current OAEV capabilities
*  We added an external payload to `FORBIDDEN_PAYLOADS` as a temporary safety fix because it maps to Atomic Red Team “Delete Filesystem - Linux” behavior and is not suitable for OpenAEV (risk of data loss/system instability).

This issue tracks a proper long-term solution so we do not rely on one-off hardcoded IDs for dangerous payloads.

### Related issues

* Closes #525 
