### PR TITLE
feat(collectors): support collector_author override in payload-producing collectors (#531)

### DIFF
--- a/atomic-red-team/atomic_red_team/configuration/collector_config_override.py
+++ b/atomic-red-team/atomic_red_team/configuration/collector_config_override.py
@@ -22,7 +22,10 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         description="Path to the icon file",
     )
     author: str | None = Field(
-        default=None,
-        description="Optional author override for this collector's payloads and "
-        "contracts. When absent, the platform attributes them to the collector's name.",
+        # Explicit author declaration (example of the override mechanism): the
+        # value matches the collector's name here, which is also what the
+        # platform would fall back to if the field were left unset.
+        default="Atomic Red Team",
+        description="Author attributed to this collector's payloads and contracts. "
+        "When unset, the platform attributes them to the collector's name.",
     )

--- a/atomic-red-team/atomic_red_team/configuration/collector_config_override.py
+++ b/atomic-red-team/atomic_red_team/configuration/collector_config_override.py
@@ -21,3 +21,8 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="atomic_red_team/img/icon-atomic-red-team.png",
         description="Path to the icon file",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this collector's payloads and "
+        "contracts. When absent, the platform attributes them to the collector's name.",
+    )

--- a/atomic-red-team/atomic_red_team/configuration/config_loader.py
+++ b/atomic-red-team/atomic_red_team/configuration/config_loader.py
@@ -25,6 +25,9 @@ class ConfigLoader(SettingsLoader):
                     "is_number": True,
                 },
                 "collector_icon_filepath": {"data": self.collector.icon_filepath},
+                # Optional author override; None lets the platform attribute the
+                # payloads to the collector's name.
+                "collector_author": {"data": self.collector.author},
             },
             config_base_model=self,
         )

--- a/openaev/openaev/configuration/collector_config_override.py
+++ b/openaev/openaev/configuration/collector_config_override.py
@@ -14,3 +14,8 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default=timedelta(days=7),
         description="Duration between two scheduled runs of the collector (ISO 8601 format).",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for this collector's payloads and "
+        "contracts. When absent, the platform attributes them to the collector's name.",
+    )

--- a/openaev/openaev/configuration/config_loader.py
+++ b/openaev/openaev/configuration/config_loader.py
@@ -27,6 +27,9 @@ class ConfigLoader(SettingsLoader):
                     "is_number": True,
                 },
                 "collector_icon_filepath": {"data": self.collector.icon_filepath},
+                # Optional author override; None lets the platform attribute the
+                # payloads to the collector's name.
+                "collector_author": {"data": self.collector.author},
             },
             config_base_model=self,
         )


### PR DESCRIPTION
### Proposed changes

* Add an optional `author` field to the `CollectorConfigOverride` of the
  two payload-producing collectors, `atomic-red-team` and `openaev` (YAML
  `collector.author` / env `COLLECTOR_AUTHOR`).
* Forward it as the `collector_author` configuration hint in their config loaders.
* Declare an explicit example author on Atomic Red Team: its `author` field defaults to
  "Atomic Red Team" as a reference example of the declaration mechanism. The value
  matches what the name fallback would produce, so the attribution is identical - the
  point is to show collector maintainers how to declare an author explicitly.
* The `openaev` collector keeps the default of `None`: with no declared author, the
  platform keeps attributing payloads and their arsenal contracts to the collector's
  name ("OpenAEV Datasets").

Note: end-to-end forwarding of `collector_author` at registration requires the pyoaev
release containing OpenAEV-Platform/client-python#318; until then the new hint is
simply inert (forward-compatible).

### Testing Instructions

1. Run the openaev collector without `collector_author`: payloads keep being authored by
   the collector's name (unchanged behavior).
2. Run the atomic-red-team collector without any author configuration: it now declares
   "Atomic Red Team" explicitly, which must attribute payloads exactly as before.
3. With a pyoaev version including client-python#318, set `collector.author` (or
   `COLLECTOR_AUTHOR`) and restart: newly upserted payloads are authored by the declared
   author organization.

### Related issues

* Closes #531
