### PR TITLE
ci(collectors): restore working deploy target until namespace tokens are provisioned (#530)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,34 +806,17 @@ jobs:
       - slack/notify:
           event: fail
           template: basic_fail_1
-  deploy_main_oaev:
+  # TODO(#530): re-enable the main-oaev / main-ff-oaev / testing-oaev /
+  # testing-xtm-one-oaev targets once a circleci ServiceAccount token is
+  # provisioned for each namespace ($K8S_TOKEN is scoped to
+  # customer-testing-oaev and $K8S_TOKEN_PRE_RELEASE is no longer valid).
+  deploy_testing:
     docker:
       - image: cimg/base:stable
     steps:
       - checkout
       - kubernetes/install-kubectl
-      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n main-oaev rollout restart deployment -l app=openaev-colljector
-  deploy_main_ff_oaev:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - kubernetes/install-kubectl
-      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n main-ff-oaev rollout restart deployment -l app=openaev-colljector
-  deploy_testing_oaev:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - kubernetes/install-kubectl
-      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n testing-oaev rollout restart deployment -l app=openaev-colljector
-  deploy_testing_xtm_one_oaev:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - kubernetes/install-kubectl
-      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_PRE_RELEASE -n testing-xtm-one-oaev rollout restart deployment -l app=openaev-colljector
+      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n customer-testing-oaev rollout restart deployment -l app=openaev-colljector
   notify_rolling:
     docker:
       - image: "cimg/base:stable"
@@ -867,25 +850,7 @@ workflows:
             branches:
               only:
                 - main
-      - deploy_main_oaev:
-          requires:
-            - publish_images
-          filters:
-            branches:
-              only: main
-      - deploy_main_ff_oaev:
-          requires:
-            - publish_images
-          filters:
-            branches:
-              only: main
-      - deploy_testing_oaev:
-          requires:
-            - publish_images
-          filters:
-            branches:
-              only: main
-      - deploy_testing_xtm_one_oaev:
+      - deploy_testing:
           requires:
             - publish_images
           filters:
@@ -893,10 +858,7 @@ workflows:
               only: main
       - notify_rolling:
           requires:
-            - deploy_main_oaev
-            - deploy_main_ff_oaev
-            - deploy_testing_oaev
-            - deploy_testing_xtm_one_oaev
+            - deploy_testing
       - notify:
           requires:
             - publish_images


### PR DESCRIPTION
### Proposed changes

* Restore the previously working `deploy_testing` CircleCI job (namespace `customer-testing-oaev`, `$K8S_TOKEN`) and wire `notify_rolling` back to it, so the `main` pipeline is green again
* Remove the four deploy jobs introduced by #527: `$K8S_TOKEN` is a ServiceAccount token scoped to `customer-testing-oaev` (`Forbidden` in `main-oaev`, `main-ff-oaev`, `testing-oaev`) and `$K8S_TOKEN_PRE_RELEASE` is no longer valid at all (401 on `testing-xtm-one-oaev`)
* Leave a TODO referencing #530 so the new targets are re-landed once infra provisions a `circleci` ServiceAccount token per namespace and exposes them to CircleCI

### Testing Instructions

1. Merge to `main`: CircleCI runs `build_docker_images` -> `publish_images` -> `deploy_testing` -> `notify_rolling`, all green
2. Failure evidence from the current `main` head (d60b24d): jobs 8405/8406/8408 fail with `deployments.apps is forbidden: User "system:serviceaccount:customer-testing-oaev:circleci" ... in the namespace "testing-oaev"`, job 8407 fails with `You must be logged in to the server`

### Related issues

* Closes #530

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

This intentionally reverts the deployment-target part of #527 only; the lint/format migration to GitHub Actions stays. Re-landing the new targets is tracked in #530 and requires infra work (per-namespace ServiceAccount tokens), not a repo change.
