### PR TITLE
ci(collectors): update deployment targets (#524)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,17 +806,34 @@ jobs:
       - slack/notify:
           event: fail
           template: basic_fail_1
-  # TODO(#530): re-enable the main-oaev / main-ff-oaev / testing-oaev /
-  # testing-xtm-one-oaev targets once a circleci ServiceAccount token is
-  # provisioned for each namespace ($K8S_TOKEN is scoped to
-  # customer-testing-oaev and $K8S_TOKEN_PRE_RELEASE is no longer valid).
-  deploy_testing:
+  deploy_main_oaev:
     docker:
       - image: cimg/base:stable
     steps:
       - checkout
       - kubernetes/install-kubectl
-      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n customer-testing-oaev rollout restart deployment -l app=openaev-colljector
+      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n main-oaev rollout restart deployment -l app=openaev-colljector
+  deploy_main_ff_oaev:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
+      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n main-ff-oaev rollout restart deployment -l app=openaev-colljector
+  deploy_testing_oaev:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
+      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n testing-oaev rollout restart deployment -l app=openaev-colljector
+  deploy_testing_xtm_one_oaev:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
+      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_PRE_RELEASE -n testing-xtm-one-oaev rollout restart deployment -l app=openaev-colljector
   notify_rolling:
     docker:
       - image: "cimg/base:stable"
@@ -850,7 +867,25 @@ workflows:
             branches:
               only:
                 - main
-      - deploy_testing:
+      - deploy_main_oaev:
+          requires:
+            - publish_images
+          filters:
+            branches:
+              only: main
+      - deploy_main_ff_oaev:
+          requires:
+            - publish_images
+          filters:
+            branches:
+              only: main
+      - deploy_testing_oaev:
+          requires:
+            - publish_images
+          filters:
+            branches:
+              only: main
+      - deploy_testing_xtm_one_oaev:
           requires:
             - publish_images
           filters:
@@ -858,7 +893,10 @@ workflows:
               only: main
       - notify_rolling:
           requires:
-            - deploy_testing
+            - deploy_main_oaev
+            - deploy_main_ff_oaev
+            - deploy_testing_oaev
+            - deploy_testing_xtm_one_oaev
       - notify:
           requires:
             - publish_images


### PR DESCRIPTION
### Proposed changes

- Re-apply the CircleCI deployment targets from #527, which were rolled back in #533 to keep main green: replace `deploy_testing` with `deploy_main_oaev`, `deploy_main_ff_oaev`, `deploy_testing_oaev` and `deploy_testing_xtm_one_oaev`, all gated on `publish_images` for `main`
- `notify_rolling` again requires all four deploy jobs, so Slack only reports success when every target rolled out
- Remove the `TODO(#530)` note added by the rollback

This is a straight revert of #533 (commit 71047b9); the resulting `.circleci/config.yml` is byte-identical to the state merged in #527 (d60b24d). The GitHub Actions lint/format and test workflows from #527 were never rolled back and are untouched here.

### Testing Instructions

1. Merge to `main`: CircleCI builds and publishes images, then restarts the collector deployments in the `main-oaev`, `main-ff-oaev`, `testing-oaev` and `testing-xtm-one-oaev` namespaces
2. Before merging, verify the prerequisite from #530 is now met. The config keeps the two existing env vars, so what is needed is authorization, not new variables: the ServiceAccount behind `$K8S_TOKEN` must have RoleBindings in `main-oaev`, `main-ff-oaev` and `testing-oaev` (it is currently scoped to `customer-testing-oaev` only), and `$K8S_TOKEN_PRE_RELEASE` must be re-provisioned as a valid token authorized in `testing-xtm-one-oaev` (it is currently invalid). Otherwise the deploy jobs will fail on main again exactly as in #530

### Related issues

- Closes #524
- Related to #530 (rollback rationale) and #533 (the rollback being reverted)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

Do not merge until the token authorizations above are confirmed, or main will go red again with the same Forbidden / not-logged-in errors described in #530. The `app=openaev-colljector` label selector is intentional: it matches the actual label in the Kubernetes manifests (pre-existing since 2836cbf) and was used by the previous working deploy job. Switching to per-namespace env vars or CircleCI contexts is an infra decision tracked in #530, deliberately out of scope for this re-apply.
