### PR TITLE
fix(collectors): guard null expectation signatures and results (#537)

### DIFF
--- a/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
+++ b/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
@@ -246,6 +246,17 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
         if not expectation.get("inject_expectation_signatures"):
             return False
 
+        # Drop malformed signature entries (missing type or null value): a null
+        # value coerced to an empty string would trivially match any alert data
+        # in the detection helper's substring comparison.
+        valid_signatures = [
+            signature
+            for signature in expectation["inject_expectation_signatures"]
+            if signature.get("type") and signature.get("value")
+        ]
+        if not valid_signatures:
+            return False
+
         alert_data = {}
         for signature_type in self.relevant_signatures_types:
             alert_data[signature_type] = {}
@@ -287,12 +298,12 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
         match_result = self.openaev_detection_helper.match_alert_elements(
             signatures=[
                 {
-                    "type": signature.get("type"),
+                    "type": signature["type"],
                     # the KQL query lowers all, filenames due to limitation in data source
                     # therefore we need to compare to lowercased strings
-                    "value": (signature.get("value") or "").lower(),
+                    "value": signature["value"].lower(),
                 }
-                for signature in expectation["inject_expectation_signatures"]
+                for signature in valid_signatures
             ],
             alert_data=alert_data,
         )

--- a/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
+++ b/microsoft-defender/microsoft_defender/openaev_microsoft_defender.py
@@ -241,6 +241,11 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
         if expectation["inject_expectation_asset"] is None:
             return False
 
+        # No signatures to match against: the platform serializes the field as
+        # null when an expectation has no signatures, so guard before iterating.
+        if not expectation.get("inject_expectation_signatures"):
+            return False
+
         alert_data = {}
         for signature_type in self.relevant_signatures_types:
             alert_data[signature_type] = {}
@@ -282,12 +287,12 @@ class OpenAEVMicrosoftDefender(CollectorDaemon):
         match_result = self.openaev_detection_helper.match_alert_elements(
             signatures=[
                 {
-                    "type": expectation.get("type"),
+                    "type": signature.get("type"),
                     # the KQL query lowers all, filenames due to limitation in data source
                     # therefore we need to compare to lowercased strings
-                    "value": expectation.get("value").lower(),
+                    "value": (signature.get("value") or "").lower(),
                 }
-                for expectation in expectation["inject_expectation_signatures"]
+                for signature in expectation["inject_expectation_signatures"]
             ],
             alert_data=alert_data,
         )

--- a/microsoft-defender/tests/test_openaev_microsoft_defender.py
+++ b/microsoft-defender/tests/test_openaev_microsoft_defender.py
@@ -167,3 +167,29 @@ def test_process_alerts_updates_detection_and_creates_trace():
     request_body = post_mock.await_args.kwargs["body"]
     assert request_body.query == TH_API_QUERY
     assert request_body.timespan
+
+
+def test_match_alert_returns_false_when_signatures_are_null():
+    """Regression test: the platform serializes inject_expectation_signatures as
+    null when an expectation has no signatures, which used to crash the whole
+    processing loop with 'NoneType' object is not iterable."""
+    collector = OpenAEVMicrosoftDefender.__new__(OpenAEVMicrosoftDefender)
+    collector.logger = MagicMock()
+
+    alert = {"AlertId": "alert-1"}
+    evidences = []
+
+    base_expectation = {
+        "inject_expectation_id": "exp-1",
+        "inject_expectation_asset": "host-1",
+    }
+
+    for signatures in (None, []):
+        expectation = {
+            **base_expectation,
+            "inject_expectation_signatures": signatures,
+        }
+        assert collector._match_alert(alert, evidences, expectation) is False
+
+    # Key entirely absent
+    assert collector._match_alert(alert, evidences, dict(base_expectation)) is False

--- a/microsoft-defender/tests/test_openaev_microsoft_defender.py
+++ b/microsoft-defender/tests/test_openaev_microsoft_defender.py
@@ -193,3 +193,27 @@ def test_match_alert_returns_false_when_signatures_are_null():
 
     # Key entirely absent
     assert collector._match_alert(alert, evidences, dict(base_expectation)) is False
+
+
+def test_match_alert_returns_false_when_signatures_are_malformed():
+    """Signatures missing a type or carrying a null value must be ignored:
+    coercing a null value to an empty string would trivially match any alert
+    data in the detection helper's substring comparison (false positive)."""
+    collector = OpenAEVMicrosoftDefender.__new__(OpenAEVMicrosoftDefender)
+    collector.logger = MagicMock()
+
+    alert = {"AlertId": "alert-1"}
+    evidences = []
+
+    for signatures in (
+        [{"type": "process_name", "value": None}],
+        [{"type": "process_name"}],
+        [{"value": "powershell.exe"}],
+        [{"type": None, "value": None}],
+    ):
+        expectation = {
+            "inject_expectation_id": "exp-1",
+            "inject_expectation_asset": "host-1",
+            "inject_expectation_signatures": signatures,
+        }
+        assert collector._match_alert(alert, evidences, expectation) is False

--- a/microsoft-sentinel/microsoft_sentinel/openaev_microsoft_sentinel.py
+++ b/microsoft-sentinel/microsoft_sentinel/openaev_microsoft_sentinel.py
@@ -80,8 +80,9 @@ class OpenAEVMicrosoftSentinel(CollectorDaemon):
 
     def _match_alert_link(self, expectation, alert_link_datas) -> bool:
         # Extract expectation alert link
+        # (inject_expectation_results is serialized as null when empty)
         alert_id_expectation = None
-        for item in expectation["inject_expectation_results"]:
+        for item in expectation.get("inject_expectation_results") or []:
             self.logger.info(item["sourceName"])
             attached_collectors = self._configuration.get(
                 "microsoft_sentinel_edr_collectors"

--- a/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
+++ b/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
@@ -163,6 +163,10 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
         # No asset
         if expectation["inject_expectation_asset"] is None:
             return False
+        # No signatures to match against: the platform serializes the field as
+        # null when an expectation has no signatures, so guard before iterating.
+        if not expectation.get("inject_expectation_signatures"):
+            return False
         # Defender / Deep Instinct (dedicated collectors)
         if alert["matchType"] in ["windows_defender", "deep_instinct"]:
             return False
@@ -209,10 +213,11 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
     # --- PROCESS ---
 
     def _is_expectation_filled(self, expectation) -> bool:
+        # inject_expectation_results is serialized as null when empty
         return any(
             er.get("sourceId", "") == self._configuration.get("collector_id")
             and er.get("result", None) is not None
-            for er in expectation["inject_expectation_results"]
+            for er in expectation.get("inject_expectation_results") or []
         )
 
     def _process_message(self) -> None:

--- a/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
+++ b/tanium-threat-response/tanium_threat_response/openaev_tanium_threat_response.py
@@ -167,6 +167,15 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
         # null when an expectation has no signatures, so guard before iterating.
         if not expectation.get("inject_expectation_signatures"):
             return False
+        # Drop malformed signature entries (missing type or null value) so the
+        # detection helper never compares None against alert data.
+        valid_signatures = [
+            signature
+            for signature in expectation["inject_expectation_signatures"]
+            if signature.get("type") and signature.get("value")
+        ]
+        if not valid_signatures:
+            return False
         # Defender / Deep Instinct (dedicated collectors)
         if alert["matchType"] in ["windows_defender", "deep_instinct"]:
             return False
@@ -202,7 +211,7 @@ class OpenAEVTaniumThreatResponse(CollectorDaemon):
                     "data": str(alert),
                 }
         match_result = self.openaev_detection_helper.match_alert_elements(
-            signatures=expectation["inject_expectation_signatures"],
+            signatures=valid_signatures,
             alert_data=alert_data,
         )
 


### PR DESCRIPTION
## Summary

- Fixes the Microsoft Defender collector crash `'NoneType' object is not iterable` reported in #537: the platform serializes `inject_expectation_signatures` as null when an expectation has no signatures, and `_match_alert` iterated it unguarded, aborting the whole processing loop so no expectation was matched anymore.
- Audits all collectors for the same class of bug and fixes the two other affected ones in the same PR:
  - **tanium-threat-response**: unguarded iteration of `inject_expectation_signatures` in `_match_alert` and of `inject_expectation_results` in `_is_expectation_filled`.
  - **microsoft-sentinel**: unguarded iteration of `inject_expectation_results` in `_match_alert_link`.
- Additionally hardens signature matching against malformed entries (review follow-up): a signature with a null `value` coerced to an empty string would trivially match any alert data in the detection helper's `simple` substring comparison, silently producing false-positive DETECTED / PREVENTED results. Both `microsoft-defender` and `tanium-threat-response` now filter out signatures missing a `type` or `value` and return False when no valid signature remains.
- Not affected (verified): crowdstrike and xtm-one already guard; all service-based collectors (elastic, qradar, splunk-es, logrhythm, netwitness, sentinelone, cortex-xdr, cortex-xsoar, template) go through the pyoaev Pydantic model which coerces null signatures to an empty list.

## Changes

- `microsoft-defender`: return early from `_match_alert` when the expectation has no signatures; filter out malformed signature entries (missing `type` or null `value`) instead of coercing null values to empty strings.
- `tanium-threat-response`: same early return and malformed-signature filter in `_match_alert`; treat null `inject_expectation_results` as an empty list in `_is_expectation_filled`.
- `microsoft-sentinel`: treat null `inject_expectation_results` as an empty list in `_match_alert_link`.
- `microsoft-defender/tests`: regression tests asserting `_match_alert` returns False (instead of raising or trivially matching) for null, empty, and absent signature lists, and for signature entries with a missing `type` or `value`.

## Test plan

- `pytest microsoft-defender/tests` passes (3 passed) against the real local pyoaev + msgraph-sdk
- `isort --profile black --check-only`, `black --check` and `flake8 --ignore=E,W` pass on the touched files from the repository root (same invocation as the Lint & Format workflow)
- Deploy the Defender collector and confirm expectations are matched again when the backlog contains signature-less expectations

Fixes #537
