### PR TITLE
feat: set proper description and tags on collector-created security platforms (#539)

### DIFF
--- a/cisco-ai-defense/cisco_ai_defense/configuration/collector_config_override.py
+++ b/cisco-ai-defense/cisco_ai_defense/configuration/collector_config_override.py
@@ -13,6 +13,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="LLM_FIREWALL",
         description="Security platform type registered for this collector.",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Cisco AI Defense, the Cisco platform inspecting LLM traffic for "
+            "prompt injections and unsafe content. Automatically registered by the "
+            "Cisco AI Defense collector, which matches inspection verdicts to "
+            "validate AI prevention and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["llm-firewall", "cisco"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="cisco_ai_defense/img/icon-cisco-ai-defense.png",
         description="Path to the icon file",

--- a/cisco-ai-defense/cisco_ai_defense/configuration/config_loader.py
+++ b/cisco-ai-defense/cisco_ai_defense/configuration/config_loader.py
@@ -18,6 +18,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/crowdstrike/crowdstrike/configuration/collector_config_override.py
+++ b/crowdstrike/crowdstrike/configuration/collector_config_override.py
@@ -12,3 +12,16 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="EDR",
         description="Platform type for the collector (e.g., EDR, SIEM, etc.).",
     )
+    platform_description: str | None = Field(
+        default=(
+            "CrowdStrike Falcon, the CrowdStrike endpoint detection and response "
+            "(EDR) platform. Automatically registered by the CrowdStrike collector, "
+            "which matches Falcon alerts to validate prevention and detection "
+            "expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["edr", "crowdstrike"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )

--- a/crowdstrike/crowdstrike/configuration/config_loader.py
+++ b/crowdstrike/crowdstrike/configuration/config_loader.py
@@ -31,6 +31,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/elastic/src/models/configs/config_loader.py
+++ b/elastic/src/models/configs/config_loader.py
@@ -36,6 +36,21 @@ class ConfigLoaderCollector(_ConfigLoaderCollector):
         default="Elastic",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "Elastic Security, the Elastic SIEM and endpoint security solution. "
+            "Automatically registered by the Elastic collector, which matches "
+            "Elastic Security alerts to validate prevention and detection "
+            "expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["siem", "elastic"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +150,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/hiddenlayer/hiddenlayer/configuration/collector_config_override.py
+++ b/hiddenlayer/hiddenlayer/configuration/collector_config_override.py
@@ -13,6 +13,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="LLM_FIREWALL",
         description="Security platform type registered for this collector.",
     )
+    platform_description: str | None = Field(
+        default=(
+            "HiddenLayer AIDR, the AI detection and response platform monitoring "
+            "interactions with AI models. Automatically registered by the "
+            "HiddenLayer collector, which matches AIDR detections to validate AI "
+            "prevention and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["llm-firewall", "hiddenlayer"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="hiddenlayer/img/icon-hiddenlayer.png",
         description="Path to the icon file",

--- a/hiddenlayer/hiddenlayer/configuration/config_loader.py
+++ b/hiddenlayer/hiddenlayer/configuration/config_loader.py
@@ -17,6 +17,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/lakera-guard/lakera_guard/configuration/collector_config_override.py
+++ b/lakera-guard/lakera_guard/configuration/collector_config_override.py
@@ -13,6 +13,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="LLM_FIREWALL",
         description="Security platform type registered for this collector.",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Lakera Guard, the AI security platform screening LLM prompts for "
+            "injections and unsafe content. Automatically registered by the Lakera "
+            "Guard collector, which matches screening results to validate AI "
+            "prevention and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["llm-firewall", "lakera"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="lakera_guard/img/icon-lakera-guard.png",
         description="Path to the icon file",

--- a/lakera-guard/lakera_guard/configuration/config_loader.py
+++ b/lakera-guard/lakera_guard/configuration/config_loader.py
@@ -16,6 +16,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/logrhythm/src/models/configs/config_loader.py
+++ b/logrhythm/src/models/configs/config_loader.py
@@ -36,6 +36,20 @@ class ConfigLoaderCollector(_ConfigLoaderCollector):
         default="LogRhythm",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "LogRhythm, the LogRhythm security information and event management "
+            "(SIEM) platform. Automatically registered by the LogRhythm collector, "
+            "which matches LogRhythm alarms to validate detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["siem", "logrhythm"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +149,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/microsoft-defender/microsoft_defender/configuration/collector_config_override.py
+++ b/microsoft-defender/microsoft_defender/configuration/collector_config_override.py
@@ -15,6 +15,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="EDR",
         description="Platform type for the collector (e.g., EDR, SIEM, etc.).",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Microsoft Defender for Endpoint, the Microsoft endpoint detection and "
+            "response (EDR) platform. Automatically registered by the Microsoft "
+            "Defender collector, which matches Defender alerts to validate "
+            "prevention and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["edr", "microsoft"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="microsoft_defender/img/icon-microsoft-defender.png",
         description="Path to the icon file",

--- a/microsoft-defender/microsoft_defender/configuration/config_loader.py
+++ b/microsoft-defender/microsoft_defender/configuration/config_loader.py
@@ -21,6 +21,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_name": {"data": self.collector.name},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]
                     "is_number": True,

--- a/microsoft-sentinel/microsoft_sentinel/configuration/collector_config_override.py
+++ b/microsoft-sentinel/microsoft_sentinel/configuration/collector_config_override.py
@@ -15,6 +15,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="SIEM",
         description="Platform type for the collector (e.g., EDR, SIEM, etc.).",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Microsoft Sentinel, the Microsoft cloud-native security information "
+            "and event management (SIEM) platform. Automatically registered by the "
+            "Microsoft Sentinel collector, which matches Sentinel incidents to "
+            "validate detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["siem", "microsoft"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="microsoft_sentinel/img/icon-microsoft-sentinel.png",
         description="Path to the icon file",

--- a/microsoft-sentinel/microsoft_sentinel/configuration/config_loader.py
+++ b/microsoft-sentinel/microsoft_sentinel/configuration/config_loader.py
@@ -21,6 +21,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_name": {"data": self.collector.name},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]
                     "is_number": True,

--- a/netwitness/src/models/configs/config_loader.py
+++ b/netwitness/src/models/configs/config_loader.py
@@ -36,6 +36,20 @@ class ConfigLoaderCollector(_ConfigLoaderCollector):
         default="NetWitness",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "NetWitness, the NetWitness network detection and response and SIEM "
+            "platform. Automatically registered by the NetWitness collector, which "
+            "matches NetWitness alerts to validate detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["siem", "netwitness"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +149,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/palo-alto-cortex-xdr/src/models/settings/config_loader.py
+++ b/palo-alto-cortex-xdr/src/models/settings/config_loader.py
@@ -36,6 +36,21 @@ class ConfigLoaderCollector(BaseConfigLoaderCollector):
         default="Palo Alto Cortex XDR",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "Palo Alto Networks Cortex XDR, the Palo Alto extended detection and "
+            "response (XDR) platform. Automatically registered by the Cortex XDR "
+            "collector, which matches Cortex XDR alerts to validate prevention and "
+            "detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["xdr", "palo-alto"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +150,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": (

--- a/palo-alto-cortex-xsoar/src/models/settings/config_loader.py
+++ b/palo-alto-cortex-xsoar/src/models/settings/config_loader.py
@@ -36,6 +36,21 @@ class ConfigLoaderCollector(BaseConfigLoaderCollector):
         default="Palo Alto Cortex XSOAR",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "Palo Alto Networks Cortex XSOAR, the Palo Alto security "
+            "orchestration, automation and response (SOAR) platform. Automatically "
+            "registered by the Cortex XSOAR collector, which matches XSOAR "
+            "incidents to validate detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["soar", "palo-alto"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -134,6 +149,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": (

--- a/prisma-airs/prisma_airs/configuration/collector_config_override.py
+++ b/prisma-airs/prisma_airs/configuration/collector_config_override.py
@@ -15,6 +15,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="LLM_FIREWALL",
         description="Security platform type registered for this collector.",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Palo Alto Networks Prisma AIRS, the AI runtime security platform "
+            "scanning LLM prompts and responses for threats. Automatically "
+            "registered by the Prisma AIRS collector, which matches scan verdicts "
+            "to validate AI prevention and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["llm-firewall", "palo-alto"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="prisma_airs/img/icon-prisma-airs.png",
         description="Path to the icon file",

--- a/prisma-airs/prisma_airs/configuration/config_loader.py
+++ b/prisma-airs/prisma_airs/configuration/config_loader.py
@@ -16,6 +16,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/prompt-security/prompt_security/configuration/collector_config_override.py
+++ b/prompt-security/prompt_security/configuration/collector_config_override.py
@@ -13,6 +13,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="LLM_FIREWALL",
         description="Security platform type registered for this collector.",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Prompt Security, the AI security platform protecting LLM applications "
+            "from prompt injections and data leakage. Automatically registered by "
+            "the Prompt Security collector, which matches security events to "
+            "validate AI prevention and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["llm-firewall", "prompt-security"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="prompt_security/img/icon-prompt-security.png",
         description="Path to the icon file",

--- a/prompt-security/prompt_security/configuration/config_loader.py
+++ b/prompt-security/prompt_security/configuration/config_loader.py
@@ -18,6 +18,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/qradar/src/models/configs/config_loader.py
+++ b/qradar/src/models/configs/config_loader.py
@@ -36,6 +36,20 @@ class ConfigLoaderCollector(_ConfigLoaderCollector):
         default="QRadar",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "IBM QRadar, the IBM security information and event management (SIEM) "
+            "platform. Automatically registered by the QRadar collector, which "
+            "matches QRadar offenses to validate detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["siem", "ibm"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +149,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/sentinelone/src/models/configs/config_loader.py
+++ b/sentinelone/src/models/configs/config_loader.py
@@ -36,6 +36,21 @@ class ConfigLoaderCollector(_ConfigLoaderCollector):
         default="SentinelOne",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "SentinelOne Singularity, the SentinelOne endpoint detection and "
+            "response (EDR) platform. Automatically registered by the SentinelOne "
+            "collector, which matches SentinelOne threats to validate prevention "
+            "and detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["edr", "sentinelone"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +150,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds())

--- a/splunk-es/src/models/configs/config_loader.py
+++ b/splunk-es/src/models/configs/config_loader.py
@@ -36,6 +36,21 @@ class ConfigLoaderCollector(_ConfigLoaderCollector):
         default="SplunkES",
         description="Name of the collector.",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=(
+            "Splunk Enterprise Security, the Splunk security information and event "
+            "management (SIEM) platform. Automatically registered by the Splunk ES "
+            "collector, which matches notable events to validate detection "
+            "expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=["siem", "splunk"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
 
 
 class ConfigLoader(ConfigBaseSettings):
@@ -135,6 +150,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/tanium-threat-response/tanium_threat_response/configuration/collector_config_override.py
+++ b/tanium-threat-response/tanium_threat_response/configuration/collector_config_override.py
@@ -15,6 +15,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
         default="EDR",
         description="Platform type for the collector (e.g., EDR, SIEM, etc.).",
     )
+    platform_description: str | None = Field(
+        default=(
+            "Tanium Threat Response, the Tanium endpoint detection and response "
+            "(EDR) module. Automatically registered by the Tanium Threat Response "
+            "collector, which matches Tanium alerts to validate prevention and "
+            "detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["edr", "tanium"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     icon_filepath: str | None = Field(
         default="tanium_threat_response/img/icon-tanium.png",
         description="Path to the icon file",

--- a/tanium-threat-response/tanium_threat_response/configuration/config_loader.py
+++ b/tanium-threat-response/tanium_threat_response/configuration/config_loader.py
@@ -20,6 +20,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds()),  # type: ignore[union-attr]

--- a/template/src/models/settings/collector_configs.py
+++ b/template/src/models/settings/collector_configs.py
@@ -52,6 +52,19 @@ class _ConfigLoaderCollector(ConfigBaseSettings):
         default="EDR",
         description="Platform type for the collector (e.g., EDR, SIEM, etc.).",
     )
+    platform_description: str | None = Field(
+        alias="COLLECTOR_PLATFORM_DESCRIPTION",
+        default=None,
+        description="Description applied to the security platform auto-created by the "
+        "collector, so its read-only card is not empty in the platform UI. Set it to a "
+        "short description of the security product this collector integrates with.",
+    )
+    platform_tags: list[str] | None = Field(
+        alias="COLLECTOR_PLATFORM_TAGS",
+        default=None,
+        description="Tag names applied to the security platform auto-created by the "
+        "collector (e.g. ['edr', 'vendor-name']).",
+    )
     log_level: LogLevel | None = Field(
         alias="COLLECTOR_LOG_LEVEL",
         default="error",

--- a/template/src/models/settings/config_loader.py
+++ b/template/src/models/settings/config_loader.py
@@ -136,6 +136,10 @@ class ConfigLoader(ConfigBaseSettings):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": int(self.collector.period.total_seconds())

--- a/xtm-one/xtm_one/configuration/collector_config_override.py
+++ b/xtm-one/xtm_one/configuration/collector_config_override.py
@@ -23,6 +23,19 @@ class CollectorConfigOverride(ConfigLoaderCollector):
             "Accepted values: EDR, XDR, SIEM, SOAR, NDR, ISPM, LLM_FIREWALL, AI_GATEWAY."
         ),
     )
+    platform_description: str | None = Field(
+        default=(
+            "Filigran XTM One, the agentic AI platform whose built-in AI defense "
+            "detects prompt injections against its agents. Automatically registered "
+            "by the XTM One collector, which matches XTM One security events to "
+            "validate AI detection expectations."
+        ),
+        description="Description applied to the security platform auto-created by the collector.",
+    )
+    platform_tags: list[str] | None = Field(
+        default=["llm-firewall", "filigran"],
+        description="Tag names applied to the security platform auto-created by the collector.",
+    )
     period: timedelta | None = Field(
         default=timedelta(minutes=5),
         description=(

--- a/xtm-one/xtm_one/configuration/config_loader.py
+++ b/xtm-one/xtm_one/configuration/config_loader.py
@@ -29,6 +29,10 @@ class ConfigLoader(SettingsLoader):
                 "collector_id": {"data": self.collector.id},
                 "collector_name": {"data": self.collector.name},
                 "collector_platform": {"data": self.collector.platform},
+                "collector_platform_description": {
+                    "data": self.collector.platform_description
+                },
+                "collector_platform_tags": {"data": self.collector.platform_tags},
                 "collector_log_level": {"data": self.collector.log_level},
                 "collector_period": {
                     "data": _optional_seconds(self.collector.period),


### PR DESCRIPTION
## Summary

- Full sweep on all 19 collectors that declare a `collector_platform`: each now provides a default `platform_description` (short description of the security product and how the collector uses it to validate expectations) and default `platform_tags` (e.g. ["edr", "microsoft"], ["siem", "splunk"], ["llm-firewall", "cisco"]) for the security platform it auto-creates, so the read-only cards are no longer empty in the Security platforms screen.
- Every `to_daemon_config()` forwards the new `collector_platform_description` / `collector_platform_tags` keys to the daemon; both fields are operator-configurable (env/config override) and optional.
- The template collector documents both fields (default None) for future collectors.

Covered: cisco-ai-defense, crowdstrike, elastic, hiddenlayer, lakera-guard, logrhythm, microsoft-defender, microsoft-sentinel, netwitness, palo-alto-cortex-xdr, palo-alto-cortex-xsoar, prisma-airs, prompt-security, qradar, sentinelone, splunk-es, tanium-threat-response, template, xtm-one. Collectors that only reference expected security platform types on payloads (openaev, atomic-red-team) do not create platform assets and are unaffected.

Requires the companion pyoaev change (OpenAEV-Platform/client-python#320) for the daemon to consume the new keys; until pyoaev is bumped the extra config hints are simply ignored, so this is safe to merge independently.

Closes #539

## Test plan

- [x] All modified files compile; black + isort + flake8 clean
- [x] Smoke test: modern-style (microsoft-defender) and old-style (qradar) config models instantiate with the new defaults
- [x] End-to-end: `ConfigLoader().to_daemon_config()` exposes `collector_platform_description` / `collector_platform_tags` to the daemon
- [ ] Visual check on a live platform once a collector runs with the updated pyoaev
