### PR TITLE
fix(cisco-ai-defense): correct authentication header to match API documentation (#461)

### DIFF
--- a/cisco-ai-defense/.env.sample
+++ b/cisco-ai-defense/.env.sample
@@ -10,4 +10,4 @@ COLLECTOR_LOG_LEVEL=error
 
 COLLECTOR_BASE_URL=ChangeMe
 COLLECTOR_API_KEY=ChangeMe
-COLLECTOR_AUTH_HEADER=X-Cisco-AI-Defense-Api-Key
+COLLECTOR_AUTH_HEADER=x-cisco-ai-defense-tenant-api-key

--- a/cisco-ai-defense/README.md
+++ b/cisco-ai-defense/README.md
@@ -77,7 +77,7 @@ section as `collector.*` keys, mapped to `COLLECTOR_*` environment variables.
 |--------------|------------------------|-----------------------------|-------------------------------|-----------|---------------------------------------------------------------------------------------------|
 | API Base URL | `collector.base_url`   | `COLLECTOR_BASE_URL`        | /                             | Yes       | Cisco AI Defense inspection API base URL (region/tenant specific), scheme + host only (e.g. `https://<region>.api.inspect.aidefense.security.cisco.com`). The collector appends `/api/v1/inspect/prompt`. |
 | API Key      | `collector.api_key`    | `COLLECTOR_API_KEY`         | /                             | Yes       | Cisco AI Defense API key.                                                                    |
-| Auth Header  | `collector.auth_header`| `COLLECTOR_AUTH_HEADER`     | `X-Cisco-AI-Defense-Api-Key`  | No        | HTTP header used to carry the API key.                                                       |
+| Auth Header  | `collector.auth_header`| `COLLECTOR_AUTH_HEADER`     | `x-cisco-ai-defense-tenant-api-key`  | No        | HTTP header used to carry the API key.                                                       |
 
 > Note: set `base_url` to the scheme + host only, with no path, query, or fragment. The collector
 > appends the inspection path itself, so a URL that already includes a path is rejected.
@@ -161,7 +161,7 @@ On each run, the collector:
   region/tenant.
 - API endpoint used:
   - `POST {base_url}/api/v1/inspect/prompt` (prompt inspection), authenticated with the configurable
-    auth header (default `X-Cisco-AI-Defense-Api-Key`).
+    auth header (default `x-cisco-ai-defense-tenant-api-key`).
 - Reference: [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html)
   (the public API surface is still consolidating; the endpoint path and auth header are configurable).
 

--- a/cisco-ai-defense/cisco_ai_defense/client.py
+++ b/cisco-ai-defense/cisco_ai_defense/client.py
@@ -27,7 +27,7 @@ class CiscoAiDefenseClient:
         self.base_url = (config.get("cisco_base_url") or "").rstrip("/")
         self.api_key = config.get("cisco_api_key")
         self.auth_header = (
-            config.get("cisco_auth_header") or "X-Cisco-AI-Defense-Api-Key"
+            config.get("cisco_auth_header") or "x-cisco-ai-defense-tenant-api-key"
         )
         self.logger = logger
         self.session = requests.Session()

--- a/cisco-ai-defense/cisco_ai_defense/config.yml.sample
+++ b/cisco-ai-defense/cisco_ai_defense/config.yml.sample
@@ -11,4 +11,4 @@ collector:
   log_level: 'error'
   base_url: 'ChangeMe'   # Cisco AI Defense inspection API base URL (region/tenant specific)
   api_key: 'ChangeMe'
-  auth_header: 'X-Cisco-AI-Defense-Api-Key'
+  auth_header: 'x-cisco-ai-defense-tenant-api-key'

--- a/cisco-ai-defense/cisco_ai_defense/configuration/collector_config_override.py
+++ b/cisco-ai-defense/cisco_ai_defense/configuration/collector_config_override.py
@@ -40,6 +40,6 @@ class CollectorConfigOverride(ConfigLoaderCollector):
     )
     api_key: str | None = Field(default=None, description="Cisco AI Defense API key.")
     auth_header: str | None = Field(
-        default="X-Cisco-AI-Defense-Api-Key",
+        default="x-cisco-ai-defense-tenant-api-key",
         description="HTTP header used to carry the API key.",
     )

--- a/cisco-ai-defense/docker-compose.yml
+++ b/cisco-ai-defense/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       - COLLECTOR_PERIOD=${COLLECTOR_PERIOD:-PT120S}
       - COLLECTOR_BASE_URL=${COLLECTOR_BASE_URL}
       - COLLECTOR_API_KEY=${COLLECTOR_API_KEY}
-      - COLLECTOR_AUTH_HEADER=${COLLECTOR_AUTH_HEADER:-X-Cisco-AI-Defense-Api-Key}
+      - COLLECTOR_AUTH_HEADER=${COLLECTOR_AUTH_HEADER:-x-cisco-ai-defense-tenant-api-key}
     restart: unless-stopped

--- a/cisco-ai-defense/tests/test_client.py
+++ b/cisco-ai-defense/tests/test_client.py
@@ -15,7 +15,7 @@ def _build_client(**overrides):
     config = {
         "cisco_base_url": "https://example.test",
         "cisco_api_key": "secret-key",
-        "cisco_auth_header": "X-Cisco-AI-Defense-Api-Key",
+        "cisco_auth_header": "x-cisco-ai-defense-tenant-api-key",
     }
     config.update(overrides)
     return CiscoAiDefenseClient(config)
@@ -151,7 +151,7 @@ def test_scan_sends_auth_header_and_ordered_messages():
 
     args, kwargs = client.session.post.call_args
     assert args[0] == "https://example.test/api/v1/inspect/prompt"
-    assert kwargs["headers"]["X-Cisco-AI-Defense-Api-Key"] == "secret-key"
+    assert kwargs["headers"]["x-cisco-ai-defense-tenant-api-key"] == "secret-key"
     assert kwargs["json"]["messages"] == [
         {"role": "system", "content": "stay safe"},
         {"role": "user", "content": "hello"},


### PR DESCRIPTION
### Proposed changes

* Correct the default authentication header for the Cisco AI Defense collector from `X-Cisco-AI-Defense-Api-Key` to `x-cisco-ai-defense-tenant-api-key`, matching the [documented API contract](https://developer.cisco.com/docs/ai-defense-management-api/).
* Update all default references consistently: `client.py`, `collector_config_override.py`, `.env.sample`, `docker-compose.yml`, `config.yml.sample`, `README.md`, and the test suite. Token/key handling semantics are unchanged.

### Testing Instructions

1. `cd cisco-ai-defense && python -m pytest tests/test_client.py` — all 20 tests pass.
2. The header value remains overridable via `COLLECTOR_AUTH_HEADER` / `collector.auth_header`.

### Related issues

* Closes #461

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

Scoped strictly to header naming consistency; no changes to token/key handling. Risk noted in the issue is deployment regression if the API silently accepted the old header — the value remains overridable via env var.
