### PR TITLE
chore(collectors): comment out EE-only tenant_id in sample configs and docker compose examples (#547)

### DIFF
--- a/atomic-red-team/.env.sample
+++ b/atomic-red-team/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/atomic-red-team/atomic_red_team/config.yml.sample
+++ b/atomic-red-team/atomic_red_team/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/atomic-red-team/docker-compose.yml
+++ b/atomic-red-team/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Atomic Red Team"}
       - COLLECTOR_PERIOD=${COLLECTOR_PERIOD:-P7D}

--- a/aws-resources/.env.sample
+++ b/aws-resources/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/aws-resources/aws_resources/config.yml.sample
+++ b/aws-resources/aws_resources/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/aws-resources/docker-compose.yml
+++ b/aws-resources/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME}
       - COLLECTOR_PERIOD=${COLLECTOR_PERIOD}

--- a/cisco-ai-defense/.env.sample
+++ b/cisco-ai-defense/.env.sample
@@ -1,6 +1,7 @@
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 COLLECTOR_ID=ChangeMe
 COLLECTOR_NAME=Cisco AI Defense

--- a/cisco-ai-defense/cisco_ai_defense/config.yml.sample
+++ b/cisco-ai-defense/cisco_ai_defense/config.yml.sample
@@ -1,6 +1,7 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
   # tenant_id: 'ChangeMe'
 
 collector:

--- a/cisco-ai-defense/docker-compose.yml
+++ b/cisco-ai-defense/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Cisco AI Defense"}
       - COLLECTOR_PLATFORM=${COLLECTOR_PLATFORM:-LLM_FIREWALL}

--- a/crowdstrike/.env.sample
+++ b/crowdstrike/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/crowdstrike/crowdstrike/config.yml.sample
+++ b/crowdstrike/crowdstrike/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:8080'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/crowdstrike/docker-compose.yml
+++ b/crowdstrike/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"CrowdStrike Endpoint Security"}
       - COLLECTOR_PERIOD=${COLLECTOR_PERIOD:-PT1M}

--- a/elastic/docker-compose.yml
+++ b/elastic/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - ELASTIC_BASE_URL=https://change.me
       # Authentication: provide ELASTIC_API_KEY (preferred) or username/password

--- a/elastic/src/.env.sample
+++ b/elastic/src/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/elastic/src/config.yml.sample
+++ b/elastic/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"
   token: "ChangeMe"
-# tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/google-workspace/.env.sample
+++ b/google-workspace/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/google-workspace/docker-compose.yml
+++ b/google-workspace/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Google Workspace"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/google-workspace/google_workspace/config.yml.sample
+++ b/google-workspace/google_workspace/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/hiddenlayer/.env.sample
+++ b/hiddenlayer/.env.sample
@@ -1,6 +1,7 @@
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 COLLECTOR_ID=ChangeMe
 COLLECTOR_NAME=HiddenLayer AIDR

--- a/hiddenlayer/docker-compose.yml
+++ b/hiddenlayer/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"HiddenLayer AIDR"}
       - COLLECTOR_PLATFORM=${COLLECTOR_PLATFORM:-LLM_FIREWALL}

--- a/hiddenlayer/hiddenlayer/config.yml.sample
+++ b/hiddenlayer/hiddenlayer/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/lakera-guard/.env.sample
+++ b/lakera-guard/.env.sample
@@ -1,6 +1,7 @@
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 COLLECTOR_ID=ChangeMe
 COLLECTOR_NAME=Lakera Guard

--- a/lakera-guard/docker-compose.yml
+++ b/lakera-guard/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Lakera Guard"}
       - COLLECTOR_PLATFORM=${COLLECTOR_PLATFORM:-LLM_FIREWALL}

--- a/lakera-guard/lakera_guard/config.yml.sample
+++ b/lakera-guard/lakera_guard/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'   # unique collector identifier

--- a/logrhythm/docker-compose.yml
+++ b/logrhythm/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      # Optional tenant ID for multi-tenant OpenAEV deployments; uncomment and set a valid UUID
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
       # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - LOGRHYTHM_BASE_URL=https://change.me

--- a/logrhythm/src/.env.sample
+++ b/logrhythm/src/.env.sample
@@ -7,9 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-# optional tenant ID for multi-tenant OpenAEV deployments
-# (leave commented out for single-tenant; must be a valid UUID if set)
-# OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/logrhythm/src/config.yml.sample
+++ b/logrhythm/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"
   token: "ChangeMe"
-# tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/microsoft-azure/.env.sample
+++ b/microsoft-azure/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/microsoft-azure/docker-compose.yml
+++ b/microsoft-azure/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME}
       - COLLECTOR_PERIOD=${COLLECTOR_PERIOD:-PT1H}

--- a/microsoft-azure/microsoft_azure/config.yml.sample
+++ b/microsoft-azure/microsoft_azure/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/microsoft-defender/.env.sample
+++ b/microsoft-defender/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/microsoft-defender/docker-compose.yml
+++ b/microsoft-defender/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Microsoft Defender"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/microsoft-defender/microsoft_defender/config.yml.sample
+++ b/microsoft-defender/microsoft_defender/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/microsoft-entra/.env.sample
+++ b/microsoft-entra/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/microsoft-entra/docker-compose.yml
+++ b/microsoft-entra/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Microsoft Entra"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/microsoft-entra/microsoft_entra/config.yml.sample
+++ b/microsoft-entra/microsoft_entra/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/microsoft-intune/.env.sample
+++ b/microsoft-intune/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/microsoft-intune/docker-compose.yml
+++ b/microsoft-intune/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME}
       - COLLECTOR_PERIOD=${COLLECTOR_PERIOD}

--- a/microsoft-intune/microsoft_intune/config.yml.sample
+++ b/microsoft-intune/microsoft_intune/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/microsoft-sentinel/.env.sample
+++ b/microsoft-sentinel/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/microsoft-sentinel/docker-compose.yml
+++ b/microsoft-sentinel/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Microsoft Sentinel"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/microsoft-sentinel/microsoft_sentinel/config.yml.sample
+++ b/microsoft-sentinel/microsoft_sentinel/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/mitre-atlas/.env.sample
+++ b/mitre-atlas/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/mitre-atlas/docker-compose.yml
+++ b/mitre-atlas/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"MITRE ATLAS"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/mitre-atlas/mitre_atlas/config.yml.sample
+++ b/mitre-atlas/mitre_atlas/config.yml.sample
@@ -1,6 +1,7 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
   # tenant_id: 'ChangeMe'
 
 collector:

--- a/mitre-attack/.env.sample
+++ b/mitre-attack/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/mitre-attack/docker-compose.yml
+++ b/mitre-attack/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"MITRE ATT&CK"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/mitre-attack/mitre_attack/config.yml.sample
+++ b/mitre-attack/mitre_attack/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/netwitness/docker-compose.yml
+++ b/netwitness/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - NETWITNESS_BASE_URL=https://change.me:50103
       # Authentication: provide username/password (Core SDK) or NETWITNESS_TOKEN (bearer)

--- a/netwitness/src/.env.sample
+++ b/netwitness/src/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/netwitness/src/config.yml.sample
+++ b/netwitness/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"
   token: "ChangeMe"
-# tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/nvd-nist-cve/.env.sample
+++ b/nvd-nist-cve/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/nvd-nist-cve/docker-compose.yml
+++ b/nvd-nist-cve/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"CVE by NVD NIST"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/nvd-nist-cve/nvd_nist_cve/config.yml.sample
+++ b/nvd-nist-cve/nvd_nist_cve/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:8080'  # Required
   token: 'ChangeMe' # Required
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe' # Required

--- a/openaev/.env.sample
+++ b/openaev/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 OPENAEV_URL_PREFIX=https://raw.githubusercontent.com/OpenAEV-Platform/payloads/refs/heads/main/
 OPENAEV_IMPORT_ONLY_NATIVE=false
 

--- a/openaev/docker-compose.yml
+++ b/openaev/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - OPENAEV_URL_PREFIX=${OPENAEV_URL_PREFIX:-https://raw.githubusercontent.com/OpenAEV-Platform/payloads/refs/heads/main/}
       - OPENAEV_IMPORT_ONLY_NATIVE=${OPENAEV_IMPORT_ONLY_NATIVE:-false}
       - COLLECTOR_ID=${COLLECTOR_ID}

--- a/openaev/openaev/config.yml.sample
+++ b/openaev/openaev/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
   url_prefix: 'https://raw.githubusercontent.com/OpenAEV-Platform/payloads/refs/heads/main/'
   import_only_native: false
 

--- a/palo-alto-cortex-xdr/docker-compose.yml
+++ b/palo-alto-cortex-xdr/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - PALO_ALTO_CORTEX_XDR_FQDN=ChangeMe
       - PALO_ALTO_CORTEX_XDR_API_KEY=ChangeMe

--- a/palo-alto-cortex-xdr/src/config.yml.sample
+++ b/palo-alto-cortex-xdr/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:8081'
   token: "ChangeMe"
-  tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/prisma-airs/.env.sample
+++ b/prisma-airs/.env.sample
@@ -1,6 +1,7 @@
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 COLLECTOR_ID=ChangeMe
 COLLECTOR_NAME=Palo Alto Prisma AIRS

--- a/prisma-airs/docker-compose.yml
+++ b/prisma-airs/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Palo Alto Prisma AIRS"}
       - COLLECTOR_PLATFORM=${COLLECTOR_PLATFORM:-LLM_FIREWALL}

--- a/prisma-airs/prisma_airs/config.yml.sample
+++ b/prisma-airs/prisma_airs/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'

--- a/prompt-security/.env.sample
+++ b/prompt-security/.env.sample
@@ -1,6 +1,7 @@
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 COLLECTOR_ID=ChangeMe
 COLLECTOR_NAME=Prompt Security

--- a/prompt-security/docker-compose.yml
+++ b/prompt-security/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Prompt Security"}
       - COLLECTOR_PLATFORM=${COLLECTOR_PLATFORM:-LLM_FIREWALL}

--- a/prompt-security/prompt_security/config.yml.sample
+++ b/prompt-security/prompt_security/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 
 collector:
   id: 'ChangeMe'   # unique UUIDv4

--- a/qradar/docker-compose.yml
+++ b/qradar/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - QRADAR_BASE_URL=https://change.me
       # Authentication: provide QRADAR_TOKEN (preferred, SEC header) or username/password

--- a/qradar/src/.env.sample
+++ b/qradar/src/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/qradar/src/config.yml.sample
+++ b/qradar/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"
   token: "ChangeMe"
-# tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/sentinelone/docker-compose.yml
+++ b/sentinelone/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - SENTINELONE_BASE_URL=https://change.me
       - SENTINELONE_API_KEY=ChangeMe

--- a/sentinelone/src/.env.sample
+++ b/sentinelone/src/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/sentinelone/src/config.yml.sample
+++ b/sentinelone/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"
   token: "ChangeMe"
-# tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/splunk-es/docker-compose.yml
+++ b/splunk-es/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - SPLUNKES_BASE_URL=https://change.me
       - SPLUNKES_USERNAME=ChangeMe

--- a/splunk-es/src/.env.sample
+++ b/splunk-es/src/.env.sample
@@ -7,7 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/splunk-es/src/config.yml.sample
+++ b/splunk-es/src/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"
   token: "ChangeMe"
-# tenant_id: "ChangeMe"
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"
 
 collector:
   id: "ChangeMe"

--- a/tanium-threat-response/.env.sample
+++ b/tanium-threat-response/.env.sample
@@ -4,7 +4,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/tanium-threat-response/docker-compose.yml
+++ b/tanium-threat-response/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"Tanium Threat Response"}
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-warn}

--- a/tanium-threat-response/tanium_threat_response/config.yml.sample
+++ b/tanium-threat-response/tanium_threat_response/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
-# tenant_id: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: 'ChangeMe'
 collector:
   id: 'ChangeMe'
   name: 'Tanium Threat Response'

--- a/template/.env.sample
+++ b/template/.env.sample
@@ -7,8 +7,8 @@
 OPENAEV_URL=ChangeMe
 # admin account API token from the OpenAEV server
 OPENAEV_TOKEN=ChangeMe
-# tenant identifier for multi-tenant deployments
-# OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 # collector ID must be a unique string, e.g. UUIDv4
 COLLECTOR_ID=ChangeMe

--- a/template/config.yml.sample
+++ b/template/config.yml.sample
@@ -1,7 +1,8 @@
 openaev:
   url: "http://change.me"  # base URL to reach the OpenAEV server
   token: "ChangeMe"  # admin account API token from the OpenAEV server
-#  tenant_id: "ChangeMe"  # tenant identifier for multi-tenant deployments
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+  # tenant_id: "ChangeMe"  # tenant identifier for multi-tenant deployments
 
 collector:
   id: "ChangeMe"  # collector ID must be a unique string, e.g. UUIDv4

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     environment:
       - OPENAEV_URL=http://localhost
       - OPENAEV_TOKEN=ChangeMe
-      - OPENAEV_TENANT_ID=ChangeMe
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=ChangeMe
       - COLLECTOR_ID=ChangeMe
       - SOURCE_KEY=ChangeMe
     restart: always

--- a/xtm-one/.env.sample
+++ b/xtm-one/.env.sample
@@ -1,6 +1,7 @@
 OPENAEV_URL=ChangeMe
 OPENAEV_TOKEN=ChangeMe
-OPENAEV_TENANT_ID=ChangeMe
+# only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+#OPENAEV_TENANT_ID=ChangeMe
 
 COLLECTOR_ID=ChangeMe
 COLLECTOR_NAME=XTM One

--- a/xtm-one/docker-compose.yml
+++ b/xtm-one/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     environment:
       - OPENAEV_URL=${OPENAEV_URL}
       - OPENAEV_TOKEN=${OPENAEV_TOKEN}
-      - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
+      # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
+      # - OPENAEV_TENANT_ID=${OPENAEV_TENANT_ID}
       - COLLECTOR_ID=${COLLECTOR_ID}
       - COLLECTOR_NAME=${COLLECTOR_NAME:-"XTM One"}
       - COLLECTOR_PLATFORM=${COLLECTOR_PLATFORM:-LLM_FIREWALL}

--- a/xtm-one/xtm_one/config.yml.sample
+++ b/xtm-one/xtm_one/config.yml.sample
@@ -1,6 +1,7 @@
 openaev:
   url: 'http://localhost:3001'
   token: 'ChangeMe'
+  # only required for multi-tenancy (Enterprise Edition), keep commented otherwise
   # tenant_id: 'ChangeMe'
 
 collector:


### PR DESCRIPTION
## Summary

- Comment out the OpenAEV `tenant_id` / `OPENAEV_TENANT_ID` parameter in all `.env.sample`, `config.yml.sample` and `docker-compose.yml` files, since it is only required for multi-tenancy (Enterprise Edition) and most EE users deploy collectors through the catalog rather than manual docker compose deployments.
- Add a uniform note above every commented occurrence: "only required for multi-tenancy (Enterprise Edition), keep commented otherwise".
- Align the few samples that were already commented (`template`, `logrhythm`, `elastic`, ...) on the same wording.
- Vendor-specific tenant IDs (Microsoft collectors) are left untouched.

No functional change: the parameter was already documented as optional in the README configuration tables; the samples now match.

## Test plan

- [ ] `rg "^OPENAEV_TENANT_ID=" -g "*.sample"` returns no active occurrence
- [ ] `rg "^\s*- OPENAEV_TENANT_ID=" -g "docker-compose*.yml"` returns no active occurrence
- [ ] No active `tenant_id` remains under the `openaev:` section of any `config.yml.sample`
- [ ] Microsoft vendor tenant IDs are unchanged

Closes #547
