### PR TITLE
ci: remove redundant apt install of curl and gettext-base (#556)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: sudo apt-get update -qq && sudo apt-get install -y -qq curl gettext-base
       - run:
           name: install dependencies
           command: pip install black isort --user
@@ -92,10 +91,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Install environment
+          name: Prepare images directory
           command: |
-            sudo apt-get update -qq
-            sudo apt install curl gettext-base
             mkdir -p ~/openaev/images
       - run:
           working_directory: ~/openaev
@@ -902,7 +899,6 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - run: sudo apt-get update -qq && sudo apt install curl gettext-base
       - slack/notify:
           event: pass
           template: basic_success_1
@@ -910,7 +906,6 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - run: sudo apt-get update -qq && sudo apt install curl gettext-base
       - slack/notify:
           event: pass
           template: basic_success_1


### PR DESCRIPTION
## Description

Removes the redundant `apt-get update && apt install curl gettext-base` step from the CircleCI jobs that run on `cimg/*` images. Both `curl` and `gettext-base` are already preinstalled in `cimg/python` and `cimg/base`, so the step does nothing useful.

## Motivation

The step is a flaky failure surface: if an apt mirror stalls, `apt-get` hangs with no output until CircleCI kills the job after the 10-minute no-output limit (`context deadline exceeded`), before the actual checks run. This was hit on the sibling `injectors` repo (job #15408) with the identical pattern. Removing the step eliminates that failure surface.

## Changes

- `ensure_formatting`: removed the apt step
- `build_docker_images` → `Install environment`: removed the two apt lines, renamed step to `Prepare images directory` (kept the `mkdir`)
- `notify_rolling`: removed the apt step
- `notify`: removed the apt step

The Alpine-based `linter` job (`apk`) is intentionally left unchanged — it uses a different base image without these packages preinstalled.

## Verification

- No `apt` occurrences remain in the affected jobs
- `.circleci/config.yml` still parses as valid YAML

Closes #556